### PR TITLE
Add conversational atomic unit chat

### DIFF
--- a/src/ui/pages/step1.py
+++ b/src/ui/pages/step1.py
@@ -1,5 +1,4 @@
 import streamlit as st
-import time
 import app_utils
 import ai
 
@@ -7,20 +6,28 @@ st.header("Step 1 - Atomic unit")
 
 with st.form("step1_form"):
     atmoic_unit_input = st.text_input(
-            "What is the atomic unit that the game should be based on?"
-        )
+        "What is the atomic unit that the game should be based on?"
+    )
     submitted = st.form_submit_button("Next")
 
 if submitted:
     app_utils.save(atmoic_unit_input)
 
-generate = st.button("Generate Ideas")
+if "messages" not in st.session_state:
+    st.session_state.messages = []
 
-if(generate):
-    atomic_unit = ai.step1()
-    atomic_unit
+generate = st.button("Generate Ideas")
+if generate:
+    answer = ai.step1(st.session_state.messages)
+    st.session_state.messages.append({"role": "assistant", "content": answer})
+
+for message in st.session_state.messages:
+    st.chat_message(message["role"]).write(message["content"])
 
 prompt = st.chat_input("Ask for help!")
-
 if prompt:
-    st.write(f"The user has sent: {prompt}")
+    st.session_state.messages.append({"role": "user", "content": prompt})
+    answer = ai.step1(st.session_state.messages)
+    st.session_state.messages.append({"role": "assistant", "content": answer})
+    st.chat_message("user").write(prompt)
+    st.chat_message("assistant").write(answer)


### PR DESCRIPTION
## Summary
- switch AI to ChatOllama and accept message history
- persist chat history in `step1.py` so user can see previous questions
- use new chat-aware API to generate answers with history

## Testing
- `python -m py_compile src/ui/ai.py src/ui/pages/step1.py`

------
https://chatgpt.com/codex/tasks/task_e_68728c4be13c832cbe711ca3acf7869f