### PR TITLE
Add helpers for saving GDSF data

### DIFF
--- a/src/gdsf/__init__.py
+++ b/src/gdsf/__init__.py
@@ -1,0 +1,1 @@
+from .main import GDSFParser

--- a/src/ui/app_utils.py
+++ b/src/ui/app_utils.py
@@ -1,14 +1,64 @@
-import pathlib
+import json
 from pathlib import Path
+
+from gdsf import GDSFParser
 
 BASE_DIR = Path(__file__).resolve().parents[1]
 DATA_PATH = BASE_DIR / "ui" / "data"
-FILE_PATH  = DATA_PATH / "info.txt"
+DATA_PATH.mkdir(exist_ok=True)
+GDSF_FILE = DATA_PATH / "info.gdsf"
 
-def save(info: str):
-    with open(FILE_PATH, "w") as f:
-        f.write(info)
 
-def load(file_path: str) -> str:
-    with open(FILE_PATH) as f:
-        return f.read()
+def _load_data() -> dict:
+    if GDSF_FILE.exists():
+        parser = GDSFParser(GDSF_FILE)
+        return parser.sections
+    return {}
+
+
+def _save_data(sections: dict) -> None:
+    with open(GDSF_FILE, "w") as f:
+        for name, values in sections.items():
+            f.write(f"[{name}]\n")
+            for k, v in values.items():
+                f.write(f"{k} = \"{v}\"\n")
+            f.write("\n")
+
+
+def save_atomic_unit(value: str) -> None:
+    data = _load_data()
+    data["atomic_unit"] = {"value": value}
+    _save_data(data)
+
+
+def load_atomic_unit() -> str:
+    data = _load_data()
+    return data.get("atomic_unit", {}).get("value", "")
+
+
+def save_atomic_skills(skills) -> None:
+    if not isinstance(skills, str):
+        skills = json.dumps(skills)
+    data = _load_data()
+    data["atomic_skills"] = {"value": skills}
+    _save_data(data)
+
+
+def load_atomic_skills():
+    data = _load_data()
+    raw = data.get("atomic_skills", {}).get("value", "")
+    try:
+        return json.loads(raw)
+    except Exception:
+        return raw
+
+
+def save_theme(theme: str) -> None:
+    data = _load_data()
+    data["theme"] = {"value": theme}
+    _save_data(data)
+
+
+def load_theme() -> str:
+    data = _load_data()
+    return data.get("theme", {}).get("value", "")

--- a/src/ui/pages/step1.py
+++ b/src/ui/pages/step1.py
@@ -11,7 +11,7 @@ with st.form("step1_form"):
     submitted = st.form_submit_button("Next")
 
 if submitted:
-    app_utils.save(atmoic_unit_input)
+    app_utils.save_atomic_unit(atmoic_unit_input)
 
 if "messages" not in st.session_state:
     st.session_state.messages = []

--- a/src/ui/pages/step2.py
+++ b/src/ui/pages/step2.py
@@ -4,7 +4,7 @@ import ai
 
 st.header("Step 2 - Atomic Skills")
 
-atomic_unit = app_utils.load("TODO")
+atomic_unit = app_utils.load_atomic_unit()
 
 if "messages" not in st.session_state:
     st.session_state.messages = []


### PR DESCRIPTION
## Summary
- make `gdsf` a package so it can be imported
- expand `app_utils` with save/load helpers using `GDSFParser`
- switch step pages to use `save_atomic_unit` and `load_atomic_unit`

## Testing
- `python -m py_compile $(git ls-files '*.py')`

------
https://chatgpt.com/codex/tasks/task_e_6872aa4b0400832c84cf30a5e4a6a13f