### PR TITLE
Add loading spinner during AI responses

### DIFF
--- a/src/ui/pages/step1.py
+++ b/src/ui/pages/step1.py
@@ -22,7 +22,8 @@ for message in st.session_state.messages:
 prompt = st.chat_input("Generate Ideas")
 if prompt:
     st.session_state.messages.append({"role": "user", "content": prompt})
-    answer = ai.step1(st.session_state.messages)
+    with st.spinner("Generating answer..."):
+        answer = ai.step1(st.session_state.messages)
     st.session_state.messages.append({"role": "assistant", "content": answer})
     st.chat_message("user").write(prompt)
     st.chat_message("assistant").write(answer)

--- a/src/ui/pages/step2.py
+++ b/src/ui/pages/step2.py
@@ -27,7 +27,8 @@ for message in st.session_state.messages:
 prompt = st.chat_input("Generate Ideas")
 if prompt:
     st.session_state.messages.append({"role": "user", "content": prompt})
-    answer = ai.step2(atomic_unit, st.session_state.messages)
+    with st.spinner("Generating answer..."):
+        answer = ai.step2(atomic_unit, st.session_state.messages)
     st.session_state.messages.append({"role": "assistant", "content": answer})
     st.chat_message("user").write(prompt)
     st.chat_message("assistant").write(answer)

--- a/src/ui/pages/step3.py
+++ b/src/ui/pages/step3.py
@@ -24,7 +24,8 @@ for message in st.session_state.messages:
 prompt = st.chat_input("Generate Ideas")
 if prompt:
     st.session_state.messages.append({"role": "user", "content": prompt})
-    answer = ai.step3(atomic_skills, st.session_state.messages)
+    with st.spinner("Generating answer..."):
+        answer = ai.step3(atomic_skills, st.session_state.messages)
     st.session_state.messages.append({"role": "assistant", "content": answer})
     st.chat_message("user").write(prompt)
     st.chat_message("assistant").write(answer)


### PR DESCRIPTION
## Summary
- show spinner while generating AI answers for all steps

## Testing
- `python -m py_compile $(git ls-files '*.py')`


------
https://chatgpt.com/codex/tasks/task_e_6872b815e9a8832c8668ffe7aa926587