### PR TITLE
Add skill kernel generation support

### DIFF
--- a/src/ui/ai.py
+++ b/src/ui/ai.py
@@ -150,6 +150,28 @@ Our Atomic Unit: {atomic_unit}
         response = model.invoke(lc_messages)
         return remove_think_block(response.content)
 
+
+def step2_kernels(atomic_unit: str, atomic_skills) -> str:
+        """Generate kernel sentences for each atomic skill."""
+        system_prompt = """
+You are a helpful assistant for the VIOLETA framework.
+Given an atomic unit and its skills, create a one-sentence kernel for each
+skill. A kernel follows the pattern: Input -> Transformation -> Output and
+uses active verbs and plain language. Return the kernels as a JSON object
+mapping each skill to its kernel sentence.
+        """
+        model = ChatOllama(
+                model="deepseek-r1:14b",
+                base_url=os.environ["OLLAMA_HOST"],
+        )
+
+        lc_messages = [SystemMessage(content=system_prompt)]
+        lc_messages.append(HumanMessage(content=f"Atomic unit: {atomic_unit}"))
+        lc_messages.append(HumanMessage(content=f"Skills: {atomic_skills}"))
+
+        response = model.invoke(lc_messages)
+        return remove_think_block(response.content)
+
 def remove_think_block(text: str) -> str:
         return re.sub(r"<think>.*?</think>\s*","", text, flags=re.DOTALL)
 

--- a/src/ui/app_utils.py
+++ b/src/ui/app_utils.py
@@ -99,3 +99,23 @@ def save_theme(theme: str) -> None:
 def load_theme() -> str:
     data = _load_data()
     return data.get("theme", {}).get("value", "")
+
+
+def save_skill_kernels(kernels: str) -> None:
+    """Save skill kernels JSON or raw string to the gdsf file."""
+    try:
+        parsed = json.loads(kernels)
+    except Exception:
+        parsed = kernels
+    data = _load_data()
+    data["skill_kernels"] = {"value": json.dumps(parsed)}
+    _save_data(data)
+
+
+def load_skill_kernels():
+    data = _load_data()
+    raw = data.get("skill_kernels", {}).get("value", "")
+    try:
+        return json.loads(raw)
+    except Exception:
+        return raw

--- a/src/ui/pages/step2.py
+++ b/src/ui/pages/step2.py
@@ -1,8 +1,9 @@
+import json
 import streamlit as st
 import app_utils
 import ai
 
-st.header("Step 2 - Atomic Skills")
+st.header("Step 2 - Atomic Skills & Kernels")
 
 atomic_unit = app_utils.load_atomic_unit()
 
@@ -17,6 +18,29 @@ with st.form("step2_form"):
 
 if submitted:
     app_utils.save_atomic_skills(atmoic_skills_input)
+
+st.subheader("Skill Kernels")
+
+loaded_kernels = app_utils.load_skill_kernels()
+if "kernels_text" not in st.session_state:
+    if loaded_kernels:
+        st.session_state.kernels_text = json.dumps(loaded_kernels, indent=2)
+    else:
+        st.session_state.kernels_text = ""
+
+st.text_area(
+    "Provide a one-sentence kernel for each skill using JSON mapping",
+    key="kernels_text",
+    height=200,
+)
+
+if st.button("Generate Kernels"):
+    with st.spinner("Generating kernels..."):
+        generated = ai.step2_kernels(atomic_unit, app_utils.load_atomic_skills())
+    st.session_state.kernels_text = generated
+
+if st.button("Save Kernels"):
+    app_utils.save_skill_kernels(st.session_state.kernels_text)
 
 if "messages" not in st.session_state:
     st.session_state.messages = []


### PR DESCRIPTION
## Summary
- enhance Step 2 page so users can generate and save skill kernels
- store skill kernels in gdsf using new helper functions
- add `step2_kernels` LLM helper to create kernels for each atomic skill

## Testing
- `python -m py_compile $(git ls-files '*.py')`

------
https://chatgpt.com/codex/tasks/task_e_687a2968a4a8832ca7cee13845e8450e