### PR TITLE
Add Step 4 emotional arc interface

### DIFF
--- a/src/ui/ai.py
+++ b/src/ui/ai.py
@@ -322,3 +322,29 @@ def step3(atomic_skills, skill_kernels, messages: List[Dict[str, str]]) -> str:
 def step3_mapping(theme: str, skill_kernels) -> str:
         """Backward compatible wrapper for step3b."""
         return step3b(theme, skill_kernels)
+
+
+def step4(theme: str, atomic_skills, messages: List[Dict[str, str]]) -> str:
+        """Generate a short emotional arc description."""
+        system_prompt = f"""
+### STEP 4 – Map the Emotional Arc
+Theme: {theme}
+Atomic skills: {atomic_skills}
+
+Write a 2–3 sentence vignette showing how a player would feel while applying these skills in this world. Then list the 3–5 key feelings in order, each with a brief explanation of which skill triggers it. Keep the answer concise.
+        """
+
+        model = ChatOllama(
+                model="deepseek-r1:14b",
+                base_url=os.environ["OLLAMA_HOST"],
+        )
+
+        lc_messages = [SystemMessage(content=system_prompt)]
+        for msg in messages:
+                if msg["role"] == "user":
+                        lc_messages.append(HumanMessage(content=msg["content"]))
+                else:
+                        lc_messages.append(AIMessage(content=msg["content"]))
+
+        response = model.invoke(lc_messages)
+        return remove_think_block(response.content)

--- a/src/ui/app_utils.py
+++ b/src/ui/app_utils.py
@@ -162,3 +162,28 @@ def load_kernel_theme_mapping():
         return json.loads(raw)
     except Exception:
         return raw
+
+
+# ---------------------------------------------------------------------------
+# Step 4: Emotional Arc helpers
+
+def save_emotional_arc(vignette: str, feelings: str, cohesion: str) -> None:
+    """Save the emotional arc information to the gdsf file."""
+    try:
+        parsed_cohesion = json.loads(cohesion)
+    except Exception:
+        parsed_cohesion = cohesion
+
+    data = _load_data()
+    payload = {"vignette": vignette, "feelings": feelings, "cohesion": parsed_cohesion}
+    data["emotional_arc"] = {"value": json.dumps(payload)}
+    _save_data(data)
+
+
+def load_emotional_arc():
+    data = _load_data()
+    raw = data.get("emotional_arc", {}).get("value", "")
+    try:
+        return json.loads(raw)
+    except Exception:
+        return {}

--- a/src/ui/pages/step4.py
+++ b/src/ui/pages/step4.py
@@ -1,0 +1,55 @@
+import json
+import streamlit as st
+import app_utils
+import ai
+
+st.header("Step 4 - Map the Emotional Arc")
+
+atomic_skills = app_utils.load_atomic_skills()
+theme = app_utils.load_theme()
+
+stored = app_utils.load_emotional_arc()
+
+vignette_default = stored.get("vignette", "") if stored else ""
+feelings_default = stored.get("feelings", "") if stored else ""
+cohesion_default = stored.get("cohesion", "") if stored else ""
+
+if isinstance(cohesion_default, (dict, list)):
+    cohesion_default = json.dumps(cohesion_default, indent=2)
+
+with st.form("step4_form"):
+    vignette_input = st.text_area(
+        "Write a short vignette describing the player's emotional journey:",
+        value=vignette_default,
+        height=80,
+    )
+    feelings_input = st.text_area(
+        "List the key feelings to evoke (one per line or JSON list):",
+        value=feelings_default,
+        height=80,
+    )
+    cohesion_input = st.text_area(
+        "Cohesion table (JSON mapping feeling to triggering skill):",
+        value=cohesion_default,
+        height=120,
+    )
+    submitted = st.form_submit_button("Save Emotional Arc")
+
+if submitted:
+    app_utils.save_emotional_arc(vignette_input, feelings_input, cohesion_input)
+
+if "messages" not in st.session_state:
+    st.session_state.messages = []
+
+for message in st.session_state.messages:
+    st.chat_message(message["role"]).write(message["content"])
+
+prompt = st.chat_input("Generate Ideas")
+if prompt:
+    st.session_state.messages.append({"role": "user", "content": prompt})
+    with st.spinner("Generating answer..."):
+        answer = ai.step4(theme, atomic_skills, st.session_state.messages)
+    st.session_state.messages.append({"role": "assistant", "content": answer})
+    st.chat_message("user").write(prompt)
+    st.chat_message("assistant").write(answer)
+


### PR DESCRIPTION
## Summary
- store and load emotional arc info in `app_utils`
- add AI helper for emotional arc suggestions
- create Streamlit page for Step 4

## Testing
- `npm test` *(fails: Error: no test specified)*
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_687cc70420c0832c8a8e4b8c4f0088d9