### PR TITLE
Remove cohesion table from step 4

### DIFF
--- a/docs/docs/theory/walkthrough.mdx
+++ b/docs/docs/theory/walkthrough.mdx
@@ -159,9 +159,8 @@ An **Emotional Arc** is the heartbeat of your game. Pin it down now and every ru
 <!-- ──────────────────────────────────────────────────────────── -->
 <!-- NEW ➜ Mini-workflow: keeps designers on rails and mirrors thesis advice -->
 :::tip Quick 3-step workflow
-1. **Write a tiny vignette** (2–3 sentences) that traces the player’s inner journey.  
-2. **List the 3-5 must-hit feelings**.  
-3. **Cohesion table** – check that each feeling flows naturally from a specific atomic-unit skill. 
+1. **Write a tiny vignette** (2–3 sentences) that traces the player’s inner journey.
+2. **List the 3-5 must-hit feelings**.
 :::
 
 <!-- NEW ➜ Explicit “no-mechanics-yet” guardrail -->
@@ -182,14 +181,6 @@ Focus solely on the inner experience; gameplay details come in Step 6.
 3. Steady progress  
 4. Confident flow  
 
-**Cohesion check**
-
-| Feeling ↔ Triggering skill | Atomic-unit skill that sparks it |
-| --- | --- |
-| Pressure | *Time-tracking* exposes how little time is left |
-| Spark of control | *Prioritisation frameworks* redirect focus |
-| Progress | *Goal-setting & reflection* reveal wins |
-| Flow | *Batching & distraction control* sustain momentum |
 :::
 
 :::tip Why this matters

--- a/docs/versioned_docs/version-0.1.0/theory/walkthrough.mdx
+++ b/docs/versioned_docs/version-0.1.0/theory/walkthrough.mdx
@@ -159,9 +159,8 @@ An **Emotional Arc** is the heartbeat of your game. Pin it down now and every ru
 <!-- ──────────────────────────────────────────────────────────── -->
 <!-- NEW ➜ Mini-workflow: keeps designers on rails and mirrors thesis advice -->
 :::tip Quick 3-step workflow
-1. **Write a tiny vignette** (2–3 sentences) that traces the player’s inner journey.  
-2. **List the 3-5 must-hit feelings**.  
-3. **Cohesion table** – check that each feeling flows naturally from a specific atomic-unit skill. 
+1. **Write a tiny vignette** (2–3 sentences) that traces the player’s inner journey.
+2. **List the 3-5 must-hit feelings**.
 :::
 
 <!-- NEW ➜ Explicit “no-mechanics-yet” guardrail -->
@@ -182,14 +181,6 @@ Focus solely on the inner experience; gameplay details come in Step 6.
 3. Steady progress  
 4. Confident flow  
 
-**Cohesion check**
-
-| Feeling ↔ Triggering skill | Atomic-unit skill that sparks it |
-| --- | --- |
-| Pressure | *Time-tracking* exposes how little time is left |
-| Spark of control | *Prioritisation frameworks* redirect focus |
-| Progress | *Goal-setting & reflection* reveal wins |
-| Flow | *Batching & distraction control* sustain momentum |
 :::
 
 :::tip Why this matters

--- a/src/ui/app_utils.py
+++ b/src/ui/app_utils.py
@@ -167,15 +167,19 @@ def load_kernel_theme_mapping():
 # ---------------------------------------------------------------------------
 # Step 4: Emotional Arc helpers
 
-def save_emotional_arc(vignette: str, feelings: str, cohesion: str) -> None:
+def save_emotional_arc(vignette: str, feelings: str, cohesion: str | None = None) -> None:
     """Save the emotional arc information to the gdsf file."""
-    try:
-        parsed_cohesion = json.loads(cohesion)
-    except Exception:
-        parsed_cohesion = cohesion
+    parsed_cohesion = None
+    if cohesion not in (None, ""):
+        try:
+            parsed_cohesion = json.loads(cohesion)
+        except Exception:
+            parsed_cohesion = cohesion
 
     data = _load_data()
-    payload = {"vignette": vignette, "feelings": feelings, "cohesion": parsed_cohesion}
+    payload = {"vignette": vignette, "feelings": feelings}
+    if parsed_cohesion is not None:
+        payload["cohesion"] = parsed_cohesion
     data["emotional_arc"] = {"value": json.dumps(payload)}
     _save_data(data)
 

--- a/src/ui/pages/step4.py
+++ b/src/ui/pages/step4.py
@@ -12,10 +12,6 @@ stored = app_utils.load_emotional_arc()
 
 vignette_default = stored.get("vignette", "") if stored else ""
 feelings_default = stored.get("feelings", "") if stored else ""
-cohesion_default = stored.get("cohesion", "") if stored else ""
-
-if isinstance(cohesion_default, (dict, list)):
-    cohesion_default = json.dumps(cohesion_default, indent=2)
 
 with st.form("step4_form"):
     vignette_input = st.text_area(
@@ -28,15 +24,10 @@ with st.form("step4_form"):
         value=feelings_default,
         height=80,
     )
-    cohesion_input = st.text_area(
-        "Cohesion table (JSON mapping feeling to triggering skill):",
-        value=cohesion_default,
-        height=120,
-    )
     submitted = st.form_submit_button("Save Emotional Arc")
 
 if submitted:
-    app_utils.save_emotional_arc(vignette_input, feelings_input, cohesion_input)
+    app_utils.save_emotional_arc(vignette_input, feelings_input)
 
 if "messages" not in st.session_state:
     st.session_state.messages = []


### PR DESCRIPTION
## Summary
- drop cohesion table input from Step 4 UI
- support optional cohesion data in `save_emotional_arc`
- update documentation to omit cohesion table instructions

## Testing
- `npm test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_687cc990428c832cb1fb48917d75823e