### PR TITLE
Add mechanics mapping substep

### DIFF
--- a/src/ui/ai.py
+++ b/src/ui/ai.py
@@ -449,3 +449,47 @@ Back-ups
 
         response = model.invoke(lc_messages)
         return remove_think_block(response.content)
+
+
+def step6_mechanic_ideas(
+    layered_feelings: str, medium: str, messages: List[Dict[str, str]]
+) -> str:
+        """Suggest mechanics for each feeling."""
+
+        system_prompt = f"""
+### STEP 6A – Map Feelings to Mechanics
+
+You are brainstorming **{medium} mechanics** that could evoke each emotional
+state listed below. Return concise suggestions using the format
+`Feeling: mechanic1, mechanic2`.
+
+Layer Feelings:
+{layered_feelings}
+
+<example>
+Layer Feelings
+- Progress
+  - Gradual control
+- Constant pressure
+
+Suggestions
+Progress: Deck-building, Skill Tree
+Gradual control: Expanding action options
+Constant pressure: Tight margin of success
+</example>
+        """
+
+        model = ChatOllama(
+                model="deepseek-r1:14b",
+                base_url=os.environ["OLLAMA_HOST"],
+        )
+
+        lc_messages = [SystemMessage(content=system_prompt)]
+        for msg in messages:
+                if msg["role"] == "user":
+                        lc_messages.append(HumanMessage(content=msg["content"]))
+                else:
+                        lc_messages.append(AIMessage(content=msg["content"]))
+
+        response = model.invoke(lc_messages)
+        return remove_think_block(response.content)

--- a/src/ui/pages/step6.py
+++ b/src/ui/pages/step6.py
@@ -1,0 +1,62 @@
+import streamlit as st
+import app_utils
+import ai
+
+st.header("Step 6 - Form a Game (FAG)")
+
+layer = app_utils.load_layered_feelings()
+if isinstance(layer, dict):
+    layer_text = app_utils.layered_feelings_to_text(layer)
+else:
+    layer_text = layer
+
+mapping = app_utils.load_mechanic_mappings()
+if isinstance(mapping, dict):
+    mapping_text = app_utils.mechanic_mappings_to_text(mapping)
+else:
+    mapping_text = mapping
+
+bmt = app_utils.load_base_mechanics_tree()
+if isinstance(bmt, dict):
+    bmt_text = app_utils.layered_feelings_to_text(bmt)
+else:
+    bmt_text = bmt
+
+medium = st.radio("Prefer mechanics from:", ["Video games", "Board games"])
+
+with st.form("step6_form"):
+    st.text_area("Layer Feelings (reference)", layer_text, height=120, disabled=True)
+    mechanics_input = st.text_area(
+        "Map each feeling to mechanics (Feeling: mechanic1, mechanic2)",
+        value=mapping_text,
+        height=160,
+    )
+    submitted = st.form_submit_button("Save Mapping")
+
+if submitted:
+    app_utils.save_mechanic_mappings(mechanics_input)
+    lf = layer if isinstance(layer, dict) else app_utils._parse_layered_feelings(layer_text)
+    mapping_dict = app_utils.load_mechanic_mappings()
+    if isinstance(mapping_dict, str):
+        mapping_dict = app_utils._parse_mechanic_mappings(mapping_dict)
+    bmt_dict = app_utils.build_base_mechanics_tree(lf, mapping_dict)
+    bmt_text = app_utils.layered_feelings_to_text(bmt_dict)
+    app_utils.save_base_mechanics_tree(bmt_text)
+
+st.subheader("Base Mechanics Tree")
+st.text_area("Auto-generated BMT", bmt_text, height=160, disabled=True)
+
+if "messages" not in st.session_state:
+    st.session_state.messages = []
+
+for message in st.session_state.messages:
+    st.chat_message(message["role"]).write(message["content"])
+
+prompt = st.chat_input("Generate Ideas")
+if prompt:
+    st.session_state.messages.append({"role": "user", "content": prompt})
+    with st.spinner("Generating answer..."):
+        answer = ai.step6_mechanic_ideas(layer_text, medium, st.session_state.messages)
+    st.session_state.messages.append({"role": "assistant", "content": answer})
+    st.chat_message("user").write(prompt)
+    st.chat_message("assistant").write(answer)


### PR DESCRIPTION
## Summary
- revise step6 AI helper to suggest mechanics for feelings
- add helper utilities for saving mechanic mappings and constructing the Base Mechanics Tree
- update step6 page to map feelings to mechanics and auto-build the BMT

## Testing
- `python -m py_compile $(git ls-files '*.py')`


------
https://chatgpt.com/codex/tasks/task_e_687cd67b0814832c9635ca5899e27135