### PR TITLE
Implement Step 7 MVP page and helpers

### DIFF
--- a/src/ui/ai.py
+++ b/src/ui/ai.py
@@ -493,3 +493,34 @@ Constant pressure: Tight margin of success
 
         response = model.invoke(lc_messages)
         return remove_think_block(response.content)
+
+
+def step7_mvp_ideas(bmt: str, messages: List[Dict[str, str]]) -> str:
+        """Suggest schema breakdowns for building the MVP."""
+
+        system_prompt = f"""
+### STEP 7 – From Base Mechanics Tree to MVP
+
+You are helping translate the following Base Mechanics Tree into concrete game
+elements for a minimal viable prototype. Suggest a short list of schemas using
+the format `Name: property` (e.g., component, action, rule). Keep each entry
+concise.
+
+Base Mechanics Tree:
+{bmt}
+        """
+
+        model = ChatOllama(
+                model="deepseek-r1:14b",
+                base_url=os.environ["OLLAMA_HOST"],
+        )
+
+        lc_messages = [SystemMessage(content=system_prompt)]
+        for msg in messages:
+                if msg["role"] == "user":
+                        lc_messages.append(HumanMessage(content=msg["content"]))
+                else:
+                        lc_messages.append(AIMessage(content=msg["content"]))
+
+        response = model.invoke(lc_messages)
+        return remove_think_block(response.content)

--- a/src/ui/app_utils.py
+++ b/src/ui/app_utils.py
@@ -399,3 +399,57 @@ def build_base_mechanics_tree(layered_feelings: dict, mapping: dict) -> dict:
         return result
 
     return recurse(layered_feelings)
+
+
+# ---------------------------------------------------------------------------
+# Step 7: List of Schemas helpers
+
+def _parse_schemas(text: str) -> list:
+    """Convert user text into a list of schema dictionaries."""
+    try:
+        data = json.loads(text)
+        if isinstance(data, list):
+            return data
+    except Exception:
+        pass
+
+    schemas = []
+    for line in text.splitlines():
+        line = line.strip()
+        if not line:
+            continue
+        if ":" in line:
+            name, prop = line.split(":", 1)
+            schemas.append({"name": name.strip(), "property": prop.strip()})
+        else:
+            schemas.append({"name": line})
+    return schemas
+
+
+def schemas_to_text(schemas: list) -> str:
+    """Serialize a schema list back into readable text."""
+    lines = []
+    for item in schemas:
+        name = item.get("name", "")
+        prop = item.get("property")
+        if prop:
+            lines.append(f"{name}: {prop}")
+        else:
+            lines.append(name)
+    return "\n".join(lines)
+
+
+def save_list_of_schemas(schemas: str) -> None:
+    parsed = _parse_schemas(schemas)
+    data = _load_data()
+    data["list_of_schemas"] = {"value": json.dumps(parsed)}
+    _save_data(data)
+
+
+def load_list_of_schemas():
+    data = _load_data()
+    raw = data.get("list_of_schemas", {}).get("value", "")
+    try:
+        return json.loads(raw)
+    except Exception:
+        return raw

--- a/src/ui/pages/step7.py
+++ b/src/ui/pages/step7.py
@@ -1,0 +1,42 @@
+import streamlit as st
+import app_utils
+import ai
+
+st.header("Step 7 - Build the MVP")
+
+bmt = app_utils.load_base_mechanics_tree()
+if isinstance(bmt, dict):
+    bmt_text = app_utils.layered_feelings_to_text(bmt)
+else:
+    bmt_text = bmt
+
+schemas = app_utils.load_list_of_schemas()
+if isinstance(schemas, list):
+    schemas_text = app_utils.schemas_to_text(schemas)
+else:
+    schemas_text = schemas
+
+with st.form("step7_form"):
+    st.text_area("Base Mechanics Tree (reference)", bmt_text, height=160, disabled=True)
+    schemas_input = st.text_area(
+        "List of Schemas (name: property)", value=schemas_text, height=160
+    )
+    submitted = st.form_submit_button("Save Schemas")
+
+if submitted:
+    app_utils.save_list_of_schemas(schemas_input)
+
+if "messages" not in st.session_state:
+    st.session_state.messages = []
+
+for message in st.session_state.messages:
+    st.chat_message(message["role"]).write(message["content"])
+
+prompt = st.chat_input("Generate Ideas")
+if prompt:
+    st.session_state.messages.append({"role": "user", "content": prompt})
+    with st.spinner("Generating answer..."):
+        answer = ai.step7_mvp_ideas(bmt_text, st.session_state.messages)
+    st.session_state.messages.append({"role": "assistant", "content": answer})
+    st.chat_message("user").write(prompt)
+    st.chat_message("assistant").write(answer)


### PR DESCRIPTION
## Summary
- add utilities for managing List of Schemas (LoS)
- add Streamlit page for Step 7 (build MVP)
- provide AI helper to suggest schema breakdowns

## Testing
- `python -m py_compile $(git ls-files '*.py')`

------
https://chatgpt.com/codex/tasks/task_e_687cea8ea1e4832c854e0a12e05c5e80