### PR TITLE
Add theme name input

### DIFF
--- a/src/ui/app_utils.py
+++ b/src/ui/app_utils.py
@@ -102,6 +102,17 @@ def load_theme() -> str:
     return data.get("theme", {}).get("value", "")
 
 
+def save_theme_name(name: str) -> None:
+    data = _load_data()
+    data["theme_name"] = {"value": name}
+    _save_data(data)
+
+
+def load_theme_name() -> str:
+    data = _load_data()
+    return data.get("theme_name", {}).get("value", "")
+
+
 def save_skill_kernels(kernels: str) -> None:
     """Save skill kernels JSON or raw string to the gdsf file."""
     try:

--- a/src/ui/pages/step3.py
+++ b/src/ui/pages/step3.py
@@ -8,6 +8,7 @@ st.header("Step 3 - Theme & Kernel Mapping")
 atomic_skills = app_utils.load_atomic_skills()
 skill_kernels = app_utils.load_skill_kernels()
 theme = app_utils.load_theme()
+theme_name = app_utils.load_theme_name()
 
 with st.form("step3_form"):
     theme_input = st.text_area(
@@ -15,10 +16,15 @@ with st.form("step3_form"):
         value=theme,
         height=80,
     )
+    theme_name_input = st.text_input(
+        "Provide a short name for this theme:",
+        value=theme_name,
+    )
     submitted = st.form_submit_button("Save Theme")
 
 if submitted:
     app_utils.save_theme(theme_input)
+    app_utils.save_theme_name(theme_name_input)
 
 st.subheader("Kernel Mapping Table")
 


### PR DESCRIPTION
## Summary
- store theme name in Step 3
- load/save theme name in app utils

## Testing
- `npm test` *(fails: Error: no test specified)*
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_68824546e2c0832c8240e52f782c129a