### PR TITLE
Reset Step 7 chat between mechanics

### DIFF
--- a/src/ui/ai.py
+++ b/src/ui/ai.py
@@ -533,16 +533,16 @@ Constant pressure: Tight margin of success
         return remove_think_block(response.content)
 
 
-def step7_mvp_ideas(bmt: str, messages: List[Dict[str, str]]) -> str:
+def step7_mvp_ideas(bmt: str, medium: str, messages: List[Dict[str, str]]) -> str:
         """Suggest schema breakdowns for building the MVP."""
 
         system_prompt = f"""
 ### STEP 7 – From Base Mechanics Tree to MVP (Recursive)
 
-We are breaking down each mechanic step by step. Encourage the user to
-identify concrete game elements, then ask how each one fits the theme and
-functions within the mechanics. Provide short suggestions using the format
-`Name: property` when requested.
+We are designing for {medium.lower()}. Break down each mechanic step by step.
+Encourage the user to identify concrete game elements, then ask how each one
+fits the theme and functions within the mechanics. Provide short suggestions
+using the format `Name: property` when requested.
 
 Base Mechanics Tree:
 {bmt}

--- a/src/ui/pages/step6.py
+++ b/src/ui/pages/step6.py
@@ -22,7 +22,14 @@ if isinstance(bmt, dict):
 else:
     bmt_text = bmt
 
-medium = st.radio("Prefer mechanics from:", ["Video games", "Board games"])
+if "medium" not in st.session_state:
+    st.session_state.medium = "Video games"
+medium = st.radio(
+    "Prefer mechanics from:",
+    ["Video games", "Board games"],
+    index=0 if st.session_state.medium == "Video games" else 1,
+)
+st.session_state.medium = medium
 
 with st.form("step6_form"):
     st.text_area("Layer Feelings (reference)", layer_text, height=120, disabled=True)

--- a/src/ui/pages/step7.py
+++ b/src/ui/pages/step7.py
@@ -4,6 +4,9 @@ import ai
 
 st.header("Step 7 - Build the MVP")
 
+# medium preference saved from Step 6
+medium = st.session_state.get("medium", "Video games")
+
 # ---------------------------------------------------------------------------
 # Load data
 bmt = app_utils.load_base_mechanics_tree()
@@ -57,6 +60,8 @@ if st.session_state.rec_queue or st.session_state.stage:
     if st.session_state.current is None:
         st.session_state.current = st.session_state.rec_queue.pop(0)
         st.session_state.stage = "decompose"
+        # reset chat messages for the new mechanic
+        st.session_state.messages = []
 
     mech = st.session_state.current
     st.subheader(f"Break down: {mech}")
@@ -111,7 +116,7 @@ prompt = st.chat_input("Generate Ideas")
 if prompt:
     st.session_state.messages.append({"role": "user", "content": prompt})
     with st.spinner("Generating answer..."):
-        answer = ai.step7_mvp_ideas(bmt_text, st.session_state.messages)
+        answer = ai.step7_mvp_ideas(bmt_text, medium, st.session_state.messages)
     st.session_state.messages.append({"role": "assistant", "content": answer})
     st.chat_message("user").write(prompt)
     st.chat_message("assistant").write(answer)


### PR DESCRIPTION
## Summary
- preserve preferred medium from Step 6 in session state
- reset Step 7 chat messages each time a new mechanic begins
- include medium when generating Step 7 ideas

## Testing
- `python -m py_compile src/ui/pages/step7.py src/ui/pages/step6.py src/ui/ai.py`
- `npm test` *(fails: Error: no test specified)*

------
https://chatgpt.com/codex/tasks/task_e_6882501f2d98832cbf3e2a6e07b61d61