### PR TITLE
Persist Step 7 queue

### DIFF
--- a/src/ui/app_utils.py
+++ b/src/ui/app_utils.py
@@ -464,3 +464,23 @@ def load_list_of_schemas():
         return json.loads(raw)
     except Exception:
         return raw
+
+
+# ---------------------------------------------------------------------------
+# Step 7 queue persistence helpers
+
+def save_step7_queue(queue: list) -> None:
+    """Persist the remaining Step 7 queue to the gdsf file."""
+    data = _load_data()
+    data["step7_queue"] = {"value": json.dumps(queue)}
+    _save_data(data)
+
+
+def load_step7_queue() -> list:
+    """Load the saved Step 7 queue if present."""
+    data = _load_data()
+    raw = data.get("step7_queue", {}).get("value", "")
+    try:
+        return json.loads(raw)
+    except Exception:
+        return []


### PR DESCRIPTION
## Summary
- add helpers to persist Step 7 queue
- reload queue from disk and skip processed mechanics
- save queue and schema list whenever progress changes

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68826b31b5fc832c9fc04276c3c91222