### PR TITLE
Implement depth-first decomposition workflow for Step 7

### DIFF
--- a/src/ui/app_utils.py
+++ b/src/ui/app_utils.py
@@ -335,6 +335,23 @@ def load_base_mechanics_tree():
         return raw
 
 
+def flatten_mechanics(tree: dict) -> list:
+    """Return a flat list of unique mechanics in a BMT."""
+    result: list[str] = []
+    seen: set[str] = set()
+
+    def recurse(node: dict) -> None:
+        for k, v in node.items():
+            if k not in seen:
+                seen.add(k)
+                result.append(k)
+            if isinstance(v, dict):
+                recurse(v)
+
+    recurse(tree)
+    return result
+
+
 # ---------------------------------------------------------------------------
 # Step 6A helpers - mechanic mappings and BMT construction
 


### PR DESCRIPTION
## Summary
- add helper `flatten_mechanics` to extract all mechanics from a BMT
- update Step 7 to preload every BMT mechanic
- process mechanics depth‑first and allow per-element theming
- persist parent info for AI suggestions

## Testing
- `pytest -q`
- `python -m py_compile src/ui/pages/step7.py src/ui/app_utils.py`


------
https://chatgpt.com/codex/tasks/task_e_688273ebb844832c9ffe6d906cae4ccb