### PR TITLE
Fix Step 7 recursion

### DIFF
--- a/src/README.md
+++ b/src/README.md
@@ -21,3 +21,7 @@ linktr.ee/violeta.framework
 ## Step 7 Workflow
 During the "Theme" stage you can now click **Done** to store an element without adding it back into the queue for further breakdown.
 After an element is saved the chat is cleared so you can start a new conversation using the `step7_theme_fit` helper to explore how it works in your theme.
+When you break down a mechanic and submit new elements, the tool returns to that
+mechanic so you can enter its thematic function before moving on to the child
+elements. The current item is stored along with the queue so closing the app no
+longer loses mechanics that haven't been processed yet.


### PR DESCRIPTION
## Summary
- update Step 7 workflow so mechanics return to their theme stage after adding children
- adjust queue data format to track stage
- document Step 7 behaviour
- persist current item in queue so leaving the page doesn't drop mechanics

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_688277076b84832c828d8c4944e539f1