### PR TITLE
Add Step 8 SIT creation

### DIFF
--- a/src/ui/ai.py
+++ b/src/ui/ai.py
@@ -607,3 +607,31 @@ Provide short suggestions on how this element could represent or operate within 
 
     response = model.invoke(lc_messages)
     return remove_think_block(response.content)
+
+def step8_sit_ideas(skills, emotions, messages: List[Dict[str, str]]) -> str:
+    """Suggest direct skill → emotion links for the SIT."""
+
+    skills_text = ", ".join(skills)
+    emo_text = ", ".join(emotions)
+    system_prompt = f"""
+### STEP 8 – Scaling Influence Table
+
+Skills:
+{skills_text}
+
+Emotions:
+{emo_text}
+
+Suggest which skills directly influence which emotions. Respond using the format `Skill: emotion1, emotion2` for a few likely connections. Only include direct effects.
+"""
+    model = get_llm()
+
+    lc_messages = [SystemMessage(content=system_prompt)]
+    for msg in messages:
+        if msg["role"] == "user":
+            lc_messages.append(HumanMessage(content=msg["content"]))
+        else:
+            lc_messages.append(AIMessage(content=msg["content"]))
+
+    response = model.invoke(lc_messages)
+    return remove_think_block(response.content)

--- a/src/ui/pages/step8.py
+++ b/src/ui/pages/step8.py
@@ -1,0 +1,87 @@
+import json
+import streamlit as st
+import app_utils
+import ai
+
+st.header("Step 8 - Scaling Influence Table (SIT)")
+
+# Load atomic-unit skills
+raw_skills = app_utils.load_atomic_skills()
+skills: list[str] = []
+if isinstance(raw_skills, dict):
+    for val in raw_skills.values():
+        if isinstance(val, list):
+            skills.extend(val)
+        else:
+            skills.append(str(val))
+elif isinstance(raw_skills, list):
+    skills = [str(s) for s in raw_skills]
+else:
+    if raw_skills:
+        skills = [str(raw_skills)]
+
+# Load top-level feelings (emotions)
+em_arc = app_utils.load_emotional_arc()
+feelings = em_arc.get("feelings", {}) if em_arc else {}
+emotions: list[str] = []
+if isinstance(feelings, dict):
+    emotions = [str(v) for v in feelings.values()]
+elif isinstance(feelings, list):
+    emotions = [str(v) for v in feelings]
+elif feelings:
+    emotions = [str(feelings)]
+
+# Load existing SIT
+def _ensure_dict(data):
+    if isinstance(data, dict):
+        return data
+    try:
+        return json.loads(data)
+    except Exception:
+        return {}
+
+existing = _ensure_dict(app_utils.load_sit())
+
+with st.form("sit_form"):
+    st.write("Mark a '+' for each direct skill → emotion influence.")
+    selections = {}
+    for skill in skills:
+        cols = st.columns(len(emotions) + 1)
+        cols[0].markdown(f"**{skill}**")
+        for idx, emo in enumerate(emotions):
+            key = f"{skill}_{emo}"
+            checked = emo in existing.get(skill, [])
+            selections[key] = cols[idx + 1].checkbox("", value=checked, key=key)
+    submitted = st.form_submit_button("Save Table")
+
+if submitted:
+    result = {}
+    for skill in skills:
+        marked = []
+        for emo in emotions:
+            key = f"{skill}_{emo}"
+            if st.session_state.get(key):
+                marked.append(emo)
+        if marked:
+            result[skill] = marked
+    app_utils.save_sit(json.dumps(result))
+    existing = result
+    st.success("SIT saved.")
+
+sit_text = app_utils.sit_to_text(existing) if isinstance(existing, dict) else str(existing)
+st.text_area("Current SIT (Skill: emotion list)", sit_text, height=160)
+
+if "messages" not in st.session_state:
+    st.session_state.messages = []
+
+for message in st.session_state.messages:
+    st.chat_message(message["role"]).write(message["content"])
+
+prompt = st.chat_input("Generate Ideas")
+if prompt:
+    st.session_state.messages.append({"role": "user", "content": prompt})
+    with st.spinner("Generating answer..."):
+        answer = ai.step8_sit_ideas(skills, emotions, st.session_state.messages)
+    st.session_state.messages.append({"role": "assistant", "content": answer})
+    st.chat_message("user").write(prompt)
+    st.chat_message("assistant").write(answer)


### PR DESCRIPTION
## Summary
- implement Step 8 page for the Scaling Influence Table (SIT)
- add helpers in `app_utils` to store/load SIT
- add `step8_sit_ideas` in `ai.py` for chat suggestions

## Testing
- `npm test` *(fails: no test specified)*
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68827c622188832c9bb1817e62db861a