### PR TITLE
feat: add triadic integration table

### DIFF
--- a/src/ui/pages/step8b.py
+++ b/src/ui/pages/step8b.py
@@ -1,0 +1,73 @@
+import streamlit as st
+import pandas as pd
+import app_utils
+
+st.header("Step 8B - Triadic Integration Table (TIT)")
+
+# Load SIT to find skill-emotion '+' pairs
+sit = app_utils.load_sit()
+if not isinstance(sit, dict):
+    sit = {}
+
+emotion_skills: dict[str, list[str]] = {}
+for skill, emos in sit.items():
+    if isinstance(emos, dict):
+        for emo, mark in emos.items():
+            if mark == '+':
+                emotion_skills.setdefault(emo, []).append(skill)
+
+if not emotion_skills:
+    st.info("No skill-emotion '+' pairs found in SIT.")
+    st.stop()
+
+emotion = st.selectbox("Select Emotion", sorted(emotion_skills.keys()))
+skills = emotion_skills.get(emotion, [])
+
+schemas = app_utils.get_schemas_for_emotion(emotion)
+
+existing_tit = app_utils.load_tit()
+if not isinstance(existing_tit, dict):
+    existing_tit = {}
+emotion_table = existing_tit.get(emotion, {})
+
+# Build initial DataFrame
+rows = []
+for schema in schemas:
+    row = {"Schema": schema}
+    for sk in skills:
+        row[sk] = emotion_table.get(schema, {}).get(sk, False)
+    row["Result"] = emotion_table.get(schema, {}).get("Result", "")
+    rows.append(row)
+
+df = pd.DataFrame(rows)
+
+with st.form("tit_form"):
+    config = {sk: st.column_config.CheckboxColumn() for sk in skills}
+    edited = st.data_editor(
+        df,
+        column_config=config,
+        disabled=["Schema"],
+        hide_index=True,
+    )
+    submitted = st.form_submit_button("Save TIT")
+
+if submitted:
+    result: dict[str, dict[str, object]] = {}
+    for row in edited.to_dict(orient="records"):
+        schema = row.get("Schema")
+        result[schema] = {sk: row.get(sk, False) for sk in skills}
+        result[schema]["Result"] = row.get("Result", "")
+    existing_tit[emotion] = result
+    app_utils.save_tit(existing_tit)
+    st.success("TIT saved.")
+
+# Display current TIT as text for reference
+current = existing_tit.get(emotion, {})
+lines = []
+for schema, vals in current.items():
+    entries = [f"{sk}: {'✔' if vals.get(sk) else ''}" for sk in skills]
+    entries.append(f"Result: {vals.get('Result', '')}")
+    lines.append(f"{schema} | " + ", ".join(entries))
+
+tit_text = "\n".join(lines)
+st.text_area("Current TIT", tit_text, height=200)


### PR DESCRIPTION
## Summary
- store and load Triadic Integration Tables with schema lookup by emotion
- add Step 8B page for editing TIT based on SIT links

## Testing
- `pytest -q`
- `python -m py_compile src/ui/app_utils.py src/ui/pages/step8b.py`


------
https://chatgpt.com/codex/tasks/task_e_688e47796d60832ca99801b3247f5267