### PR TITLE
feat: allow explanations in TIT

### DIFF
--- a/src/ui/ai.py
+++ b/src/ui/ai.py
@@ -635,3 +635,23 @@ Suggest which skills directly influence which emotions. Respond using the format
 
     response = model.invoke(lc_messages)
     return remove_think_block(response.content)
+
+
+def step8b_cell(schema: str, skill: str, emotion: str) -> str:
+    """Explain how a schema can influence an atomic skill."""
+
+    system_prompt = f"""
+### STEP 8B – Triadic Integration Table
+
+Emotion: {emotion}
+Schema: {schema}
+Atomic skill: {skill}
+
+In one concise sentence, describe how the schema could influence or relate to the atomic skill in the game's context.
+Return only the sentence.
+"""
+
+    model = get_llm()
+    lc_messages = [SystemMessage(content=system_prompt)]
+    response = model.invoke(lc_messages)
+    return remove_think_block(response.content)


### PR DESCRIPTION
## Summary
- make Triadic Integration Table allow text-based explanations instead of checkboxes
- add LLM-powered suggestion button for TIT cell explanations

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_688e4be45794832cbf496f880baf1c06