### PR TITLE
Fix TIT table updating for emotion change

### DIFF
--- a/src/ui/pages/step8b.py
+++ b/src/ui/pages/step8b.py
@@ -45,7 +45,9 @@ for schema in schemas:
 
 df = pd.DataFrame(rows)
 
-if "tit_df" not in st.session_state:
+# Reset the table whenever a different emotion is selected
+if st.session_state.get("tit_emotion") != emotion:
+    st.session_state.tit_emotion = emotion
     st.session_state.tit_df = df
 
 def generate_suggestions():


### PR DESCRIPTION
## Summary
- Reset TIT data when selecting a different emotion so the table shows the correct schemas

## Testing
- `pytest -q`
- `npm test` *(fails: no test specified)*

------
https://chatgpt.com/codex/tasks/task_e_688e5011bf24832c8387a88bafe69988