### PR TITLE
Add game description generator

### DIFF
--- a/src/ui/ai.py
+++ b/src/ui/ai.py
@@ -661,3 +661,21 @@ def step8b_cell(kernel: str, mechanic: str, emotion: str) -> str:
     ]
     response = model.invoke(lc_messages)
     return remove_think_block(response.content)
+
+
+def generate_game_description(data: dict) -> str:
+    """Generate a high-level game description from gathered data."""
+    system_prompt = (
+        "You are a helpful assistant for the VIOLETA framework. "
+        "Using the provided structured data, craft a concise and "
+        "readable description of the envisioned game so that a reader can "
+        "easily visualize how the game works and what it teaches."
+    )
+    model = get_llm()
+    content = json.dumps(data, indent=2)
+    lc_messages = [
+        SystemMessage(content=system_prompt),
+        HumanMessage(content=f"Game data:\n{content}"),
+    ]
+    response = model.invoke(lc_messages)
+    return remove_think_block(response.content)

--- a/src/ui/app_utils.py
+++ b/src/ui/app_utils.py
@@ -26,6 +26,37 @@ def _save_data(sections: dict) -> None:
             f.write("\n")
 
 
+REQUIRED_SECTIONS = [
+    "atomic_unit",
+    "atomic_skills",
+    "skill_kernels",
+    "theme",
+    "theme_name",
+    "kernel_theme_mapping",
+    "emotional_arc",
+    "layered_feelings",
+    "mechanic_mappings",
+    "base_mechanics_tree",
+    "list_of_schemas",
+    "sit_table",
+    "tit_table",
+]
+
+
+def load_all_sections() -> dict:
+    """Return all sections stored in the gdsf file."""
+    return _load_data()
+
+
+def all_steps_completed() -> bool:
+    """Return True when every wizard step has been saved."""
+    data = _load_data()
+    for key in REQUIRED_SECTIONS:
+        if key not in data or not data[key].get("value"):
+            return False
+    return True
+
+
 def save_atomic_unit(value: str) -> None:
     data = _load_data()
     data["atomic_unit"] = {"value": value}

--- a/src/ui/streamlit_app.py
+++ b/src/ui/streamlit_app.py
@@ -1,5 +1,20 @@
 import streamlit as st
+import app_utils
+import ai
 
 st.set_page_config(page_title="VIOLETA Wizard", layout="wide")
 st.title("🎮 VIOLETA Framework Wizard")
 st.sidebar.success("Select a step above.")
+
+if st.sidebar.button(
+    "Generate Game Description",
+    disabled=not app_utils.all_steps_completed(),
+):
+    info = app_utils.load_all_sections()
+    with st.spinner("Generating description..."):
+        description = ai.generate_game_description(info)
+    st.session_state["game_description"] = description
+
+if "game_description" in st.session_state:
+    st.subheader("Game Description")
+    st.write(st.session_state["game_description"])


### PR DESCRIPTION
## Summary
- Add sidebar button to generate an LLM-powered game description from collected wizard data
- Track completion of required wizard steps and enable the button only when all data is present
- Implement `generate_game_description` to summarize the GDSF info via the configured LLM

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_688f794b3ef4832ca6e6b54578417479