### PR TITLE
docs: note unsuported physical skills

### DIFF
--- a/docs/docs/theory/walkthrough.mdx
+++ b/docs/docs/theory/walkthrough.mdx
@@ -49,6 +49,10 @@ If you’d like to explore each method in detail—including examples, worksheet
 
 An Atomic Unit is a tightly‑coupled cluster of competencies that the player must exercise together so often that they start to feel like one fluent behaviour. Think of it as the smallest “learning package” worth practising in isolation before layering on new content. A clear Atomic Unit lets every subsequent design decision point back to a single, memorable north‑star.
 
+:::caution Practical skills not yet supported
+Atomic units that rely on bodily control—like horse riding or knife handling—aren't implemented in this version. These practical skills will be supported in a future release, so please avoid using them as atomic units for now.
+:::
+
 Below you’ll see three sample Atomic Units. Each bold headline names the unit; the indented bullets show the sub‑skills that compose it.
 :::note Example(s)
 

--- a/docs/versioned_docs/version-0.1.0/theory/walkthrough.mdx
+++ b/docs/versioned_docs/version-0.1.0/theory/walkthrough.mdx
@@ -49,6 +49,10 @@ If you’d like to explore each method in detail—including examples, worksheet
 
 An Atomic Unit is a tightly‑coupled cluster of competencies that the player must exercise together so often that they start to feel like one fluent behaviour. Think of it as the smallest “learning package” worth practising in isolation before layering on new content. A clear Atomic Unit lets every subsequent design decision point back to a single, memorable north‑star.
 
+:::caution Practical skills not yet supported
+Atomic units that rely on bodily control—like horse riding or knife handling—aren't implemented in this version. These practical skills will be supported in a future release, so please avoid using them as atomic units for now.
+:::
+
 Below you’ll see three sample Atomic Units. Each bold headline names the unit; the indented bullets show the sub‑skills that compose it.
 :::note Example(s)
 

--- a/src/ui/pages/step1.py
+++ b/src/ui/pages/step1.py
@@ -3,6 +3,11 @@ import app_utils
 import ai
 
 st.header("Step 1 - Atomic unit")
+st.info(
+    "Practical skills that require bodily control (e.g., horse riding or knife handling) "
+    "are not yet supported. These will be implemented in a future version, so please "
+    "avoid using them as atomic units."
+)
 
 with st.form("step1_form"):
     atomic_unit_input = st.text_input(


### PR DESCRIPTION
## Summary
- inform users at Step 1 that physical skills such as horse riding and knife handling are not yet supported
- document the limitation in the walkthrough so atomic units based on bodily control are avoided

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_6890a7974108832cb492c26273244517