### PR TITLE
Add learning type selector for step 1

### DIFF
--- a/src/ui/app_utils.py
+++ b/src/ui/app_utils.py
@@ -64,6 +64,21 @@ def load_atomic_unit() -> str:
     return data.get("atomic_unit", {}).get("value", "")
 
 
+def save_learning_types(types: list[str]) -> None:
+    data = _load_data()
+    data["learning_types"] = {"value": json.dumps(types)}
+    _save_data(data)
+
+
+def load_learning_types() -> list[str]:
+    data = _load_data()
+    raw = data.get("learning_types", {}).get("value", "[]")
+    try:
+        return json.loads(raw)
+    except Exception:
+        return []
+
+
 def _parse_atomic_skills(text: str):
     """Parse user input for atomic skills.
 

--- a/src/ui/pages/step1.py
+++ b/src/ui/pages/step1.py
@@ -9,13 +9,45 @@ st.info(
     "avoid using them as atomic units."
 )
 
+saved_types = app_utils.load_learning_types()
+
 with st.form("step1_form"):
+    st.subheader("Learning Types")
+    declarative = st.checkbox(
+        "Declarative (static) – facts, concepts, schemas",
+        value="declarative" in saved_types,
+        key="lt_declarative",
+    )
+    procedural = st.checkbox(
+        "Procedural (dynamic) – algorithms, skills, sequences",
+        value="procedural" in saved_types,
+        key="lt_procedural",
+    )
+    st.checkbox(
+        "Psychomotor – fine- and gross-motor execution",
+        disabled=True,
+        key="lt_psychomotor",
+    )
+    metacognitive = st.checkbox(
+        "Metacognitive / Conditional – when & why to deploy 1-3",
+        value="metacognitive" in saved_types,
+        key="lt_metacognitive",
+    )
     atomic_unit_input = st.text_input(
-        "What is the atomic unit that the game should be based on?"
+        "What is the atomic unit that the game should be based on?",
+        value=app_utils.load_atomic_unit(),
     )
     submitted = st.form_submit_button("Next")
 
 if submitted:
+    selected = []
+    if declarative:
+        selected.append("declarative")
+    if procedural:
+        selected.append("procedural")
+    if metacognitive:
+        selected.append("metacognitive")
+    app_utils.save_learning_types(selected)
     app_utils.save_atomic_unit(atomic_unit_input)
 
 if "messages" not in st.session_state:


### PR DESCRIPTION
## Summary
- integrate learning type selection into Streamlit step1 page and persist choices
- add helpers for saving and loading selected learning types
- remove unused Astro Step 1 page and navigation link

## Testing
- `npm test` *(fails: Error: no test specified)*
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_6890d0097850832cb9acc57cd4ebd02d