### PR TITLE
feat: add learning type selection for atomic skills

### DIFF
--- a/src/ui/ai.py
+++ b/src/ui/ai.py
@@ -153,12 +153,24 @@ atomic skill: Modulo Division Hashing
                         result = []
                         for val in sk.values():
                                 if isinstance(val, list):
-                                        result.extend(val)
+                                        for item in val:
+                                                if isinstance(item, dict):
+                                                        result.append(item.get("name", ""))
+                                                else:
+                                                        result.append(item)
+                                elif isinstance(val, dict):
+                                        result.append(val.get("name", ""))
                                 else:
                                         result.append(val)
-                        return result
+                        return [s for s in result if s]
                 if isinstance(sk, list):
-                        return sk
+                        result = []
+                        for item in sk:
+                                if isinstance(item, dict):
+                                        result.append(item.get("name", ""))
+                                else:
+                                        result.append(item)
+                        return [s for s in result if s]
                 return [s.strip() for s in str(sk).splitlines() if s.strip()]
 
         skills = _flatten(atomic_skills)

--- a/src/ui/app_utils.py
+++ b/src/ui/app_utils.py
@@ -117,8 +117,38 @@ def _parse_atomic_skills(text: str):
     return skills
 
 
-def save_atomic_skills(skills: str) -> None:
-    parsed = _parse_atomic_skills(skills)
+def atomic_skills_to_text(skills) -> str:
+    """Convert stored atomic skills structure back to editable text."""
+    if isinstance(skills, dict):
+        lines: list[str] = []
+        for cat, items in skills.items():
+            lines.append(str(cat))
+            for item in items:
+                if isinstance(item, dict):
+                    lines.append(str(item.get("name", "")))
+                else:
+                    lines.append(str(item))
+            lines.append("")
+        return "\n".join(lines).strip()
+    if isinstance(skills, list):
+        lines = []
+        for item in skills:
+            if isinstance(item, dict):
+                lines.append(str(item.get("name", "")))
+            else:
+                lines.append(str(item))
+        return "\n".join(lines)
+    if isinstance(skills, str):
+        return skills
+    return ""
+
+
+def save_atomic_skills(skills) -> None:
+    """Save atomic skills which may already be parsed with types."""
+    if isinstance(skills, str):
+        parsed = _parse_atomic_skills(skills)
+    else:
+        parsed = skills
     data = _load_data()
     data["atomic_skills"] = {"value": json.dumps(parsed)}
     _save_data(data)
@@ -131,6 +161,34 @@ def load_atomic_skills():
         return json.loads(raw)
     except Exception:
         return raw
+
+
+def skill_names(skills) -> list[str]:
+    """Return a flat list of skill names from a saved skills structure."""
+    names: list[str] = []
+    if isinstance(skills, dict):
+        for val in skills.values():
+            if isinstance(val, list):
+                for item in val:
+                    if isinstance(item, dict):
+                        names.append(str(item.get("name", "")))
+                    else:
+                        names.append(str(item))
+            elif isinstance(val, dict):
+                names.append(str(val.get("name", "")))
+            else:
+                names.append(str(val))
+    elif isinstance(skills, list):
+        for item in skills:
+            if isinstance(item, dict):
+                names.append(str(item.get("name", "")))
+            else:
+                names.append(str(item))
+    elif isinstance(skills, str):
+        names = [line.strip() for line in skills.splitlines() if line.strip()]
+    elif skills:
+        names = [str(skills)]
+    return [n for n in names if n]
 
 
 def save_theme(theme: str) -> None:

--- a/src/ui/pages/step8.py
+++ b/src/ui/pages/step8.py
@@ -7,18 +7,7 @@ st.header("Step 8 - Scaling Influence Table (SIT)")
 
 # Load atomic-unit skills
 raw_skills = app_utils.load_atomic_skills()
-skills: list[str] = []
-if isinstance(raw_skills, dict):
-    for val in raw_skills.values():
-        if isinstance(val, list):
-            skills.extend(val)
-        else:
-            skills.append(str(val))
-elif isinstance(raw_skills, list):
-    skills = [str(s) for s in raw_skills]
-else:
-    if raw_skills:
-        skills = [str(raw_skills)]
+skills = app_utils.skill_names(raw_skills)
 
 # Load top-level feelings (emotions)
 em_arc = app_utils.load_emotional_arc()


### PR DESCRIPTION
## Summary
- extend Step 2 to choose a learning type for each atomic skill and persist that information
- store and load typed skill structures, keeping text form for editing
- update AI kernel generation and SIT processing to handle typed skills
- simplify Step 8 to show only skill names in the SIT

## Testing
- `python -m pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_6890d8b527c8832cb84ad3dc700c750f