### PR TITLE
Preserve declarative kernels in step3b

### DIFF
--- a/src/ui/ai.py
+++ b/src/ui/ai.py
@@ -295,15 +295,12 @@ def step3b(theme: str, skill_kernels) -> str:
                         if ktype in ("procedural", "metacognitive"):
                                 proc_meta.setdefault(skill, []).append(kernel)
                         elif ktype == "declarative":
-                                declaratives.append(
-                                        {
-                                                "kernel": skill,
-                                                "input": kernel.get("input", ""),
-                                                "verb": kernel.get("verb", ""),
-                                                "output": kernel.get("output", ""),
-                                                "preserved": "Y",
-                                        }
-                                )
+                                # Declarative kernels are not adapted to the theme.
+                                # Preserve the original kernel exactly as provided,
+                                # only marking that its logic remains intact.
+                                preserved_kernel = dict(kernel)
+                                preserved_kernel.setdefault("preserved", "Y")
+                                declaratives.append(preserved_kernel)
 
         system_prompt = """
 ### STEP 3B \u2013 KERNEL-BY-KERNEL MAPPING

--- a/tests/test_step3b.py
+++ b/tests/test_step3b.py
@@ -1,0 +1,42 @@
+import json
+import sys
+import types
+from pathlib import Path
+
+# Ensure src directory is available for imports
+sys.path.append(str(Path(__file__).resolve().parents[1] / "src"))
+
+# Provide a minimal stub for the optional 'dotenv' dependency required by ui.ai
+dotenv_stub = types.ModuleType("dotenv")
+dotenv_stub.load_dotenv = lambda *args, **kwargs: None
+sys.modules.setdefault("dotenv", dotenv_stub)
+
+from ui.ai import step3b
+
+def test_step3b_preserves_declarative_kernel():
+    skill_kernels = {
+        "Skill": [
+            {
+                "kernel": "Original kernel",
+                "input": "input",
+                "verb": "do",
+                "output": "output",
+                "type": "declarative",
+            }
+        ]
+    }
+    theme = "Test Theme"
+    result = step3b(theme, skill_kernels)
+    data = json.loads(result)
+    assert data["theme"] == theme
+    assert data["kernels"] == [
+        {
+            "kernel": "Original kernel",
+            "input": "input",
+            "verb": "do",
+            "output": "output",
+            "type": "declarative",
+            "preserved": "Y",
+        }
+    ]
+


### PR DESCRIPTION
## Summary
- Ensure step3b keeps declarative kernels untouched, only flagging them as preserved
- Add regression test verifying declarative kernels remain unchanged

## Testing
- `pytest -q`
- `npm test` *(fails: Error: no test specified)*

------
https://chatgpt.com/codex/tasks/task_e_68921e89288c832c81b84a3935af21a7