### PR TITLE
feat: persist learning types selection

### DIFF
--- a/src/ui/app_utils.py
+++ b/src/ui/app_utils.py
@@ -32,6 +32,7 @@ REQUIRED_SECTIONS = [
     "skill_kernels",
     "theme",
     "theme_name",
+    "learning_types",
     "kernel_theme_mapping",
     "emotional_arc",
     "layered_feelings",
@@ -62,6 +63,26 @@ def save_atomic_unit(value: str) -> None:
 def load_atomic_unit() -> str:
     data = _load_data()
     return data.get("atomic_unit", {}).get("value", "")
+
+
+def save_learning_types(types: list[str]) -> None:
+    """Persist selected learning types to the gdsf file."""
+    data = _load_data()
+    data["learning_types"] = {"value": json.dumps(types)}
+    _save_data(data)
+
+
+def load_learning_types() -> list[str]:
+    """Return the learning types stored in the gdsf file."""
+    data = _load_data()
+    raw = data.get("learning_types", {}).get("value", "[]")
+    try:
+        loaded = json.loads(raw)
+        if isinstance(loaded, list):
+            return loaded
+        return [str(loaded)]
+    except Exception:
+        return []
 
 
 def _parse_atomic_skills(text: str):

--- a/src/ui/pages/step1.py
+++ b/src/ui/pages/step1.py
@@ -9,35 +9,49 @@ st.info(
     "avoid using them as atomic units."
 )
 
+saved_types = set(app_utils.load_learning_types())
+saved_atomic_unit = app_utils.load_atomic_unit()
+
 with st.form("step1_form"):
 
     st.subheader("Learning Types")
-    st.checkbox(
+    lt_declarative = st.checkbox(
         "Declarative (static) – facts, concepts, schemas",
-        disabled=True,
         key="lt_declarative",
+        value="Declarative" in saved_types,
     )
-    st.checkbox(
+    lt_procedural = st.checkbox(
         "Procedural (dynamic) – algorithms, skills, sequences",
-        disabled=True,
         key="lt_procedural",
+        value="Procedural" in saved_types,
     )
-    st.checkbox(
+    lt_psychomotor = st.checkbox(
         "Psychomotor – fine- and gross-motor execution",
-        disabled=True,
         key="lt_psychomotor",
+        value="Psychomotor" in saved_types,
     )
-    st.checkbox(
+    lt_metacognitive = st.checkbox(
         "Metacognitive / Conditional – when & why to deploy 1-3",
-        disabled=True,
         key="lt_metacognitive",
+        value="Metacognitive" in saved_types,
     )
     atomic_unit_input = st.text_input(
-        "What is the atomic unit that the game should be based on?"
+        "What is the atomic unit that the game should be based on?",
+        value=saved_atomic_unit,
     )
     submitted = st.form_submit_button("Next")
 
 if submitted:
+    selected_types = []
+    if lt_declarative:
+        selected_types.append("Declarative")
+    if lt_procedural:
+        selected_types.append("Procedural")
+    if lt_psychomotor:
+        selected_types.append("Psychomotor")
+    if lt_metacognitive:
+        selected_types.append("Metacognitive")
+    app_utils.save_learning_types(selected_types)
     app_utils.save_atomic_unit(atomic_unit_input)
 
 if "messages" not in st.session_state:

--- a/src/ui/pages/step2.py
+++ b/src/ui/pages/step2.py
@@ -6,6 +6,9 @@ import ai
 st.header("Step 2 - Atomic Skills & Kernels")
 
 atomic_unit = app_utils.load_atomic_unit()
+learning_types = app_utils.load_learning_types()
+if learning_types:
+    st.write("Learning Types: " + ", ".join(learning_types))
 
 with st.form("step2_form"):
     atomic_skills_input = st.text_area(

--- a/tests/test_learning_types.py
+++ b/tests/test_learning_types.py
@@ -1,0 +1,17 @@
+import tempfile
+from pathlib import Path
+import sys
+
+sys.path.append(str(Path(__file__).resolve().parents[1] / "src"))
+import ui.app_utils as app_utils  # noqa: E402
+
+
+def test_save_load_learning_types(tmp_path, monkeypatch):
+    # Redirect data path to temporary directory
+    data_dir = tmp_path
+    gdsf_file = data_dir / "info.gdsf"
+    monkeypatch.setattr(app_utils, "DATA_PATH", data_dir)
+    monkeypatch.setattr(app_utils, "GDSF_FILE", gdsf_file)
+    types = ["Declarative", "Procedural"]
+    app_utils.save_learning_types(types)
+    assert app_utils.load_learning_types() == types


### PR DESCRIPTION
## Summary
- enable learning type selection and persist to GDSF
- expose helpers to save/load learning types across steps
- show selected learning types in later steps and add tests

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68933819e844832c803c3151bbb428e6