### PR TITLE
feat: categorize atomic skills by learning type

### DIFF
--- a/src/ui/app_utils.py
+++ b/src/ui/app_utils.py
@@ -123,8 +123,20 @@ def _parse_atomic_skills(text: str):
     return skills
 
 
-def save_atomic_skills(skills: str) -> None:
-    parsed = _parse_atomic_skills(skills)
+def save_atomic_skills(skills) -> None:
+    """Persist atomic skills to the gdsf file.
+
+    ``skills`` may be either a raw string entered by the user or a dictionary
+    mapping learning types to lists of skills. If a string is provided, the
+    existing ``_parse_atomic_skills`` helper is used for backwards
+    compatibility. Dictionaries are written as-is.
+    """
+
+    if isinstance(skills, str):
+        parsed = _parse_atomic_skills(skills)
+    else:
+        parsed = skills
+
     data = _load_data()
     data["atomic_skills"] = {"value": json.dumps(parsed)}
     _save_data(data)

--- a/src/ui/pages/step2.py
+++ b/src/ui/pages/step2.py
@@ -10,17 +10,25 @@ learning_types = app_utils.load_learning_types()
 if learning_types:
     st.write("Learning Types: " + ", ".join(learning_types))
 
+st.write(
+    "What knowledge, actions, and/or skills are necessary to master this atomic unit?"
+)
+
 with st.form("step2_form"):
-    atomic_skills_input = st.text_area(
-        "What knowledge, actions, and/or skills are necessary to master this atomic unit?\n\n"
-        "You can group skills by entering a category name followed by its skills on separate lines.\n"
-        "Leave a blank line between categories.",
-        height=200,
-    )
+    skill_inputs = {}
+    for lt in learning_types:
+        skill_inputs[lt] = st.text_area(
+            f"{lt} Skills",
+            height=120,
+        )
     submitted = st.form_submit_button("Next")
 
 if submitted:
-    app_utils.save_atomic_skills(atomic_skills_input)
+    parsed = {
+        lt: [s.strip() for s in text.splitlines() if s.strip()]
+        for lt, text in skill_inputs.items()
+    }
+    app_utils.save_atomic_skills(parsed)
 
 st.subheader("Skill Kernels")
 

--- a/tests/test_atomic_skills.py
+++ b/tests/test_atomic_skills.py
@@ -1,0 +1,18 @@
+import sys
+from pathlib import Path
+
+import pytest
+
+sys.path.append(str(Path(__file__).resolve().parents[1] / "src"))
+import ui.app_utils as app_utils  # noqa: E402
+
+
+def test_save_load_atomic_skills_per_type(tmp_path, monkeypatch):
+    data_dir = tmp_path
+    gdsf_file = data_dir / "info.gdsf"
+    monkeypatch.setattr(app_utils, "DATA_PATH", data_dir)
+    monkeypatch.setattr(app_utils, "GDSF_FILE", gdsf_file)
+
+    skills = {"Declarative": ["fact1", "fact2"], "Procedural": ["step1"]}
+    app_utils.save_atomic_skills(skills)
+    assert app_utils.load_atomic_skills() == skills


### PR DESCRIPTION
## Summary
- Allow users to input atomic skills per selected learning type in Step 2.
- Persist skills grouped by learning type and ensure compatibility with existing parsing.
- Add regression test for saving and loading atomic skills per learning type.

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68933e727bb4832cbf1f31259cb7c7fb