### PR TITLE
Add learning type to generated kernels

### DIFF
--- a/src/ui/ai.py
+++ b/src/ui/ai.py
@@ -187,8 +187,18 @@ output:
                         cleaned = remove_code_fences(cleaned)
                         try:
                                 data = json.loads(cleaned)
+                                for k, kernels in list(data.items()):
+                                        if isinstance(kernels, list):
+                                                for kernel in kernels:
+                                                        if isinstance(kernel, dict):
+                                                                kernel["learning_type"] = lt
+                                        elif isinstance(kernels, dict):
+                                                kernels["learning_type"] = lt
+                                                data[k] = [kernels]
+                                        else:
+                                                data[k] = [{"kernel": kernels, "learning_type": lt}]
                         except Exception:
-                                data = {skill: cleaned}
+                                data = {skill: [{"kernel": cleaned, "learning_type": lt}]}
                         results.update(data)
 
         return json.dumps(results, indent=2)

--- a/tests/test_step2_kernels.py
+++ b/tests/test_step2_kernels.py
@@ -36,3 +36,6 @@ def test_step2_kernels_prompts(monkeypatch):
     assert "passive" in recorded["Fact"].lower()
     assert "imperative" in recorded["Action"].lower()
     assert "cognitive" in recorded["Reflection"].lower()
+    assert data["Fact"][0]["learning_type"] == "Declarative"
+    assert data["Action"][0]["learning_type"] == "Procedural"
+    assert data["Reflection"][0]["learning_type"] == "Metacognitive"


### PR DESCRIPTION
## Summary
- Attach learning_type tag to each kernel produced by step2_kernels
- Extend step2_kernels tests to expect learning type metadata

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_6895cd978fd8832cb8c49fa9a087e39b