### PR TITLE
Add kernel identifiers and benefit mapping UI

### DIFF
--- a/src/ui/ai.py
+++ b/src/ui/ai.py
@@ -270,6 +270,17 @@ output:
                                 data = {skill: [{"kernel": cleaned, "learning_type": lt}]}
                         results.update(data)
 
+        # Ensure each kernel has a unique id and a "fact" alias of the kernel text
+        counter = 1
+        for kernels in results.values():
+                if isinstance(kernels, list):
+                        for kernel in kernels:
+                                if isinstance(kernel, dict):
+                                        kernel.setdefault("id", f"k{counter}")
+                                        if "fact" not in kernel and "kernel" in kernel:
+                                                kernel["fact"] = kernel["kernel"]
+                                        counter += 1
+
         return json.dumps(results, indent=2)
 
 

--- a/src/ui/app_utils.py
+++ b/src/ui/app_utils.py
@@ -34,6 +34,8 @@ REQUIRED_SECTIONS = [
     "theme_name",
     "learning_types",
     "kernel_theme_mapping",
+    "kernel_benefits",
+    "kernel_benefit_mappings",
     "emotional_arc",
     "layered_feelings",
     "mechanic_mappings",
@@ -210,6 +212,46 @@ def save_kernel_mappings(mappings: str) -> None:
 def load_kernel_mappings():
     data = _load_data()
     raw = data.get("kernel_mappings", {}).get("value", "")
+    try:
+        return json.loads(raw)
+    except Exception:
+        return raw
+
+
+def save_kernel_benefits(benefits: str) -> None:
+    """Save kernel benefits to the gdsf file."""
+    try:
+        parsed = json.loads(benefits)
+    except Exception:
+        parsed = benefits
+    data = _load_data()
+    data["kernel_benefits"] = {"value": json.dumps(parsed)}
+    _save_data(data)
+
+
+def load_kernel_benefits():
+    data = _load_data()
+    raw = data.get("kernel_benefits", {}).get("value", "")
+    try:
+        return json.loads(raw)
+    except Exception:
+        return raw
+
+
+def save_kernel_benefit_mappings(mappings: str) -> None:
+    """Save kernel to benefit mapping table."""
+    try:
+        parsed = json.loads(mappings)
+    except Exception:
+        parsed = mappings
+    data = _load_data()
+    data["kernel_benefit_mappings"] = {"value": json.dumps(parsed)}
+    _save_data(data)
+
+
+def load_kernel_benefit_mappings():
+    data = _load_data()
+    raw = data.get("kernel_benefit_mappings", {}).get("value", "")
     try:
         return json.loads(raw)
     except Exception:

--- a/tests/test_step2_kernels.py
+++ b/tests/test_step2_kernels.py
@@ -39,3 +39,5 @@ def test_step2_kernels_prompts(monkeypatch):
     assert data["Fact"][0]["learning_type"] == "Declarative"
     assert data["Action"][0]["learning_type"] == "Procedural"
     assert data["Reflection"][0]["learning_type"] == "Metacognitive"
+    assert "id" in data["Fact"][0]
+    assert data["Fact"][0]["fact"] == data["Fact"][0]["kernel"]


### PR DESCRIPTION
## Summary
- assign unique IDs and fact alias to generated kernels
- store and manage kernel "why it matters" benefits and mappings
- add Step 2 UI for selecting or adding benefits to kernels
- test kernel id generation

## Testing
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_6895df2ade2c832c91ed6c281d2fb48f