### PR TITLE
Remove redundant fact field from kernels

### DIFF
--- a/src/ui/ai.py
+++ b/src/ui/ai.py
@@ -271,7 +271,7 @@ output:
                                 data = {skill: [{"kernel": cleaned, "learning_type": lt}]}
                         results.update(data)
 
-        # Ensure each kernel has a unique id and a "fact" alias of the kernel text
+        # Ensure each kernel has a unique id
         counter = 1
         for kernels in results.values():
                 if isinstance(kernels, list):

--- a/src/ui/pages/step2.py
+++ b/src/ui/pages/step2.py
@@ -92,8 +92,6 @@ if isinstance(skill_kernels, dict):
 for idx, kernel in enumerate(all_kernels, start=1):
     if isinstance(kernel, dict):
         kernel.setdefault("id", f"k{idx}")
-        if "fact" not in kernel and "kernel" in kernel:
-            kernel["fact"] = kernel["kernel"]
 
 benefit_options = list(benefits.values())
 

--- a/tests/test_step2_kernels.py
+++ b/tests/test_step2_kernels.py
@@ -40,4 +40,5 @@ def test_step2_kernels_prompts(monkeypatch):
     assert data["Action"][0]["learning_type"] == "Procedural"
     assert data["Reflection"][0]["learning_type"] == "Metacognitive"
     assert "id" in data["Fact"][0]
-    assert data["Fact"][0]["fact"] == data["Fact"][0]["kernel"]
+    assert "kernel" in data["Fact"][0]
+    assert "fact" not in data["Fact"][0]


### PR DESCRIPTION
## Summary
- Drop legacy `fact` alias for kernel text in `step2_kernels`
- Simplify kernel processing and storage on Step 2 page
- Adjust tests to expect only `kernel` and `id`

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_6895e58189e8832cb4fc9e17f5d0daa8