### PR TITLE
Add on-demand why-it-matters generation to Step2

### DIFF
--- a/src/ui/ai.py
+++ b/src/ui/ai.py
@@ -145,7 +145,7 @@ output:
       "kernel": "Transform readable data into unreadable data with a reversible rule.",
       "input": "readable data",
       "verb": "transform into",
-      "output": "unreadable data with a reversible rule",
+      "output": "unreadable data with a reversible rule"
     }
   ]
 }
@@ -193,7 +193,7 @@ output:
       "kernel": "Evaluate candidate solutions against criteria to select the best option.",
       "input": "candidate solutions",
       "verb": "evaluate",
-      "output": "best option",
+      "output": "best option"
     }
   ]
 }
@@ -281,6 +281,41 @@ output:
                                         counter += 1
 
         return json.dumps(results, indent=2)
+
+
+def step2_why_it_matters(atomic_unit: str, kernel: dict) -> List[str]:
+        """Generate 1-3 short reasons why a kernel matters."""
+        system_prompt = """
+You are a helpful assistant for the VIOLETA framework.
+Given an atomic unit and a kernel mapping (with input, verb, output),
+provide 1-3 brief reasons why the kernel matters. Return the reasons
+as a JSON list of strings ordered from most to least important.
+
+Example:
+<example>
+atomic unit: Knife Skills
+kernel: {"kernel": "Slice whole vegetables into uniform strips.", "input": "whole vegetables", "verb": "slice", "output": "uniform strips"}
+output: ["ensures even cooking"]
+</example>
+        """
+
+        model = get_llm()
+        lc_messages = [SystemMessage(content=system_prompt)]
+        lc_messages.append(HumanMessage(content=f"Atomic unit: {atomic_unit}"))
+        lc_messages.append(HumanMessage(content=f"Kernel: {json.dumps(kernel)}"))
+
+        response = model.invoke(lc_messages)
+        cleaned = remove_think_block(response.content)
+        cleaned = remove_code_fences(cleaned)
+        try:
+                data = json.loads(cleaned)
+                if isinstance(data, list):
+                        return [str(r).strip() for r in data if str(r).strip()]
+                if isinstance(data, str):
+                        return [data.strip()]
+        except Exception:
+                pass
+        return [cleaned.strip()] if cleaned.strip() else []
 
 
 

--- a/src/ui/pages/step2.py
+++ b/src/ui/pages/step2.py
@@ -108,6 +108,12 @@ if "benefit_inputs" not in st.session_state:
             "new": "",
         }
 
+
+def suggest_benefits(kern):
+    with st.spinner("Generating why it matters..."):
+        reasons = ai.step2_why_it_matters(atomic_unit, kern)
+    st.session_state.benefit_inputs[kern["id"]]["new"] = "\n".join(reasons)
+
 for kernel in all_kernels:
     st.markdown(f"**{kernel.get('kernel', '')}**")
     st.session_state.benefit_inputs[kernel["id"]]["selected"] = st.multiselect(
@@ -121,6 +127,11 @@ for kernel in all_kernels:
         value=st.session_state.benefit_inputs[kernel["id"]]["new"],
         key=f"new_{kernel['id']}",
         height=80,
+    )
+    st.button(
+        "Generate Why It Matters",
+        key=f"gen_{kernel['id']}",
+        on_click=lambda k=kernel: suggest_benefits(k),
     )
     st.write("---")
 

--- a/tests/test_step2_kernels.py
+++ b/tests/test_step2_kernels.py
@@ -42,3 +42,21 @@ def test_step2_kernels_prompts(monkeypatch):
     assert "id" in data["Fact"][0]
     assert "kernel" in data["Fact"][0]
     assert "fact" not in data["Fact"][0]
+
+
+def test_step2_why_it_matters(monkeypatch):
+    recorded = {}
+
+    class FakeModel:
+        def invoke(self, messages):
+            recorded["messages"] = [m.content for m in messages]
+            return SimpleNamespace(content=json.dumps(["r1", "r2"]))
+
+    monkeypatch.setattr(ai, "get_llm", lambda: FakeModel())
+
+    kernel = {"kernel": "k", "input": "i", "verb": "v", "output": "o"}
+    reasons = ai.step2_why_it_matters("Unit", kernel)
+
+    assert reasons == ["r1", "r2"]
+    assert any("Atomic unit: Unit" == m for m in recorded["messages"])
+    assert any("Kernel:" in m for m in recorded["messages"])


### PR DESCRIPTION
## Summary
- Separate why-it-matters reasoning from kernel creation
- Add AI prompt and per-kernel button to suggest benefits on demand
- Update tests for new prompt

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_6895e7a8bf2c832c9981effa95ec63f8