### PR TITLE
Ensure kernel benefits initialize correctly

### DIFF
--- a/src/ui/pages/step2.py
+++ b/src/ui/pages/step2.py
@@ -97,16 +97,16 @@ benefit_options = list(benefits.values())
 
 if "benefit_inputs" not in st.session_state:
     st.session_state.benefit_inputs = {}
-    for kernel in all_kernels:
-        existing = [
-            benefits[m["benefit_id"]]
-            for m in benefit_mappings
-            if m.get("kernel_id") == kernel.get("id") and m.get("benefit_id") in benefits
-        ]
-        st.session_state.benefit_inputs[kernel["id"]] = {
-            "selected": existing,
-            "new": "",
-        }
+
+for kernel in all_kernels:
+    existing = [
+        benefits[m["benefit_id"]]
+        for m in benefit_mappings
+        if m.get("kernel_id") == kernel.get("id") and m.get("benefit_id") in benefits
+    ]
+    st.session_state.benefit_inputs.setdefault(
+        kernel["id"], {"selected": existing, "new": ""}
+    )
 
 
 def suggest_benefits(kern):


### PR DESCRIPTION
## Summary
- Avoid missing benefit input IDs by initializing session state for every kernel each run

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_6895f35b80fc832cabc4fe94a227dfbf