### PR TITLE
feat: enrich step3a with kernel benefits

### DIFF
--- a/src/ui/ai.py
+++ b/src/ui/ai.py
@@ -385,11 +385,27 @@ output:
 
 
 
-def step3a(atomic_skills, messages: List[Dict[str, str]]) -> str:
+def step3a(atomic_skills, kernels_with_benefits, messages: List[Dict[str, str]]) -> str:
         """Return a chat-based response for choosing a theme."""
         system_prompt = """
-### STEP 3A \u2013 PICK A CANDIDATE THEME
-Answer the question: "In what kind of world or situation would someone need to use the skills from my atomic unit regularly?" Provide a two-sentence mood blurb describing the world's flavour, stakes and common activities.
+### STEP 3A – PICK A CANDIDATE THEME
+Answer the question: “In what kind of world or situation would someone need to use the skills from my atomic unit regularly?”
+
+Write a 4–6 sentence mood blurb that:
+
+Describes the world’s flavour, atmosphere, and stakes.
+
+Explains the player’s role and common activities in that setting.
+
+Briefly shows how each type of skill (Declarative, Procedural, Metacognitive) fits naturally into this world.
+    • For Declarative kernels, do not just restate the fact — use its benefit (“why it matters”) to give it an in-world effect or consequence.
+    • For Procedural and Metacognitive kernels, draw from their Input → Verb → Output logic directly.
+
+Ensure the theme is cohesive, emotionally engaging, and offers multiple opportunities to practice all the skills.
+
+Output format:
+Theme name: [short, evocative title]
+Theme blurb: [4–6 sentences as described above]
 
 Examples:
 <example>
@@ -397,22 +413,26 @@ atomic unit: Programming Syntax
 atomic skills: ["Data types", "Variables declaration and assignment", "Operators and their precedence", "Control flow (conditionals, loops)", "Functions definition and invocation", "Scope management", "Arrays and collections syntax", "Error handling", "String manipulation functions"]
 output:
 Fantasy Theme: Magic and Code
-In a realm where technology and magic intertwine, the world of Arcanecode is governed by the principles of programming and spellcasting. Wizards and sorcerers wielding arcane knowledge cast spells using intricate code syntax, 
-with data types representing different magical elements—fire, water, earth, and air. Variables declaration and assignment are essential for assigning magical energies or resources, while operators and precedence dictate the 
-order in which spells are combined. Control flow through conditionals and loops governs the decision-making processes of magic, such as casting protective shields until a specific condition is met. Functions definition and 
-invocation allow for reusable spells and magical constructs, while scope management limits the effect of spells to certain areas or durations. Error handling is crucial for addressing failed spells or unexpected magical reactions, 
-and string manipulation shapes and alters magical runes or incantations. In this world, the stakes are high—incorrect code can lead to disastrous consequences like spells backfiring or magical energy overflows. Being a skilled programmer 
+In a realm where technology and magic intertwine, the world of Arcanecode is governed by the principles of programming and spellcasting. Wizards and sorcerers wielding arcane knowledge cast spells using intricate code syntax,
+with data types representing different magical elements—fire, water, earth, and air. Variables declaration and assignment are essential for assigning magical energies or resources, while operators and precedence dictate the
+order in which spells are combined. Control flow through conditionals and loops governs the decision-making processes of magic, such as casting protective shields until a specific condition is met. Functions definition and
+invocation allow for reusable spells and magical constructs, while scope management limits the effect of spells to certain areas or durations. Error handling is crucial for addressing failed spells or unexpected magical reactions,
+and string manipulation shapes and alters magical runes or incantations. In this world, the stakes are high—incorrect code can lead to disastrous consequences like spells backfiring or magical energy overflows. Being a skilled programmer
 in Arcanecode is not just a talent; it is essential for survival and success in a realm where magic is powered by code.
 
 </example>
 
 Our Atomic Skills: {atomic_skills}
+Our Kernels with Benefits: {kernels_with_benefits}
         """
         model = get_llm()
 
         lc_messages = [SystemMessage(content=system_prompt)]
 
         lc_messages.append(HumanMessage(content=f"My atomic skills are: {atomic_skills}"))
+        lc_messages.append(
+                HumanMessage(content=f"My kernels with benefits are: {kernels_with_benefits}")
+        )
         for msg in messages:
                 if msg["role"] == "user":
                         lc_messages.append(HumanMessage(content=msg["content"]))
@@ -578,9 +598,11 @@ def remove_code_fences(text: str) -> str:
         return text.strip()
 
 
-def step3(atomic_skills, skill_kernels, messages: List[Dict[str, str]]) -> str:
+def step3(
+        atomic_skills, skill_kernels, kernels_with_benefits, messages: List[Dict[str, str]]
+) -> str:
         """Return a chat-based response using Step 3A then Step 3B."""
-        theme = step3a(atomic_skills, messages)
+        theme = step3a(atomic_skills, kernels_with_benefits, messages)
         mapping = step3b(theme, skill_kernels)
         return f"{theme}\n\n{mapping}"
 


### PR DESCRIPTION
## Summary
- Extend Step3a to accept kernels with their "why it matters" benefits
- Build and pass enriched kernel data in Step3 page and Step3 wrapper
- Update prompts so themes reference kernel benefits alongside skills

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_689607030b54832cbd25bd66d39d1fcf