### PR TITLE
feat: add sequential kernel analogy step

### DIFF
--- a/src/ui/app_utils.py
+++ b/src/ui/app_utils.py
@@ -258,6 +258,26 @@ def load_kernel_benefit_mappings():
         return raw
 
 
+def save_kernel_analogies(analogies) -> None:
+    """Persist selected kernel analogies to the gdsf file."""
+    try:
+        parsed = json.loads(analogies)
+    except Exception:
+        parsed = analogies
+    data = _load_data()
+    data["kernel_analogies"] = {"value": json.dumps(parsed)}
+    _save_data(data)
+
+
+def load_kernel_analogies():
+    data = _load_data()
+    raw = data.get("kernel_analogies", {}).get("value", "{}")
+    try:
+        return json.loads(raw)
+    except Exception:
+        return raw
+
+
 # Functions for saving the kernel-theme mapping produced in Step 3B
 def save_kernel_theme_mapping(info: str) -> None:
     """Save Step 3B table to the gdsf file."""

--- a/src/ui/pages/step3.py
+++ b/src/ui/pages/step3.py
@@ -3,15 +3,14 @@ import streamlit as st
 import app_utils
 import ai
 
-st.header("Step 3 - Theme & Kernel Mapping")
+st.header("Step 3A - Kernel Analogies")
 
-atomic_skills = app_utils.load_atomic_skills()
 skill_kernels = app_utils.load_skill_kernels()
 kernel_benefits = app_utils.load_kernel_benefits() or {}
 benefit_mappings = app_utils.load_kernel_benefit_mappings() or []
 
-# Build kernels enriched with their "why it matters" benefits
-kernels_with_benefits: dict = {}
+# Build a flattened list of kernels enriched with their "why it matters" benefits
+kernels_with_benefits: list = []
 if isinstance(skill_kernels, dict):
     benefit_lookup: dict[str, list[str]] = {}
     for mapping in benefit_mappings:
@@ -22,19 +21,89 @@ if isinstance(skill_kernels, dict):
             if mapping.get("copy_override"):
                 text = mapping["copy_override"]
             benefit_lookup.setdefault(kid, []).append(text)
-
     for skill, kern_list in skill_kernels.items():
-        new_list = []
         if isinstance(kern_list, list):
             for kern in kern_list:
                 enriched = dict(kern)
                 benefits = benefit_lookup.get(kern.get("id"), [])
                 if benefits:
                     enriched["why_it_matters"] = benefits
-                new_list.append(enriched)
-        kernels_with_benefits[skill] = new_list
+                enriched["skill"] = skill
+                kernels_with_benefits.append(enriched)
 else:
-    kernels_with_benefits = skill_kernels
+    if isinstance(skill_kernels, list):
+        kernels_with_benefits = skill_kernels
+
+# Session state for progress
+if "kernel_index" not in st.session_state:
+    st.session_state.kernel_index = 0
+if "kernel_analogies" not in st.session_state:
+    st.session_state.kernel_analogies = app_utils.load_kernel_analogies() or {}
+if "generated_analogies" not in st.session_state:
+    st.session_state.generated_analogies = []
+
+
+def parse_analogies(text: str) -> list[str]:
+    blocks: list[str] = []
+    current: list[str] = []
+    for line in text.strip().splitlines():
+        if line.startswith("Analogy"):
+            if current:
+                blocks.append("\n".join(current).strip())
+                current = []
+        current.append(line)
+    if current:
+        blocks.append("\n".join(current).strip())
+    return [b for b in blocks if b]
+
+
+total = len(kernels_with_benefits)
+if st.session_state.kernel_index < total:
+    k = kernels_with_benefits[st.session_state.kernel_index]
+    st.subheader(f"Kernel {st.session_state.kernel_index + 1} of {total}")
+    st.markdown(f"**{k.get('kernel', '')}**")
+    manual = st.text_area("Write your own analogies (one per line)", key="manual_analogy")
+
+    if st.button("Generate analogies"):
+        with st.spinner("Generating analogies..."):
+            raw = ai.step3a(k)
+        st.session_state.generated_analogies = parse_analogies(raw)
+
+    for idx, ana in enumerate(st.session_state.generated_analogies):
+        st.checkbox(f"Select Analogy {idx + 1}", key=f"gen_{idx}")
+        st.markdown(ana)
+
+    if st.button("Save and Next"):
+        selected: list[str] = []
+        for idx, ana in enumerate(st.session_state.generated_analogies):
+            if st.session_state.get(f"gen_{idx}"):
+                selected.append(ana)
+            if f"gen_{idx}" in st.session_state:
+                del st.session_state[f"gen_{idx}"]
+
+        manual_list = [line.strip() for line in manual.splitlines() if line.strip()]
+        selected.extend(manual_list)
+
+        key = k.get("id") or k.get("kernel")
+        st.session_state.kernel_analogies[key] = {
+            "kernel": k.get("kernel"),
+            "skill": k.get("skill"),
+            "analogies": selected,
+        }
+        app_utils.save_kernel_analogies(st.session_state.kernel_analogies)
+        st.session_state.kernel_index += 1
+        st.session_state.generated_analogies = []
+        st.session_state.manual_analogy = ""
+        st.experimental_rerun()
+else:
+    st.success("All kernels processed.")
+    st.subheader("Selected Analogies")
+    for item in st.session_state.kernel_analogies.values():
+        st.markdown(f"**{item.get('kernel', '')}**")
+        for ana in item.get("analogies", []):
+            st.write(ana)
+
+st.header("Step 3B - Theme & Kernel Mapping")
 
 theme = app_utils.load_theme()
 theme_name = app_utils.load_theme_name()
@@ -68,23 +137,3 @@ st.text_area("Step 3B Table (JSON)", key="info_text", height=200)
 
 if st.button("Save Additional Info"):
     app_utils.save_kernel_theme_mapping(st.session_state.info_text)
-
-if "messages" not in st.session_state:
-    st.session_state.messages = []
-
-for message in st.session_state.messages:
-    st.chat_message(message["role"]).write(message["content"])
-
-prompt = st.chat_input("Generate Ideas")
-if prompt:
-    st.session_state.messages.append({"role": "user", "content": prompt})
-    with st.spinner("Generating answer..."):
-        answer = ai.step3(
-            atomic_skills,
-            skill_kernels,
-            kernels_with_benefits,
-            st.session_state.messages,
-        )
-    st.session_state.messages.append({"role": "assistant", "content": answer})
-    st.chat_message("user").write(prompt)
-    st.chat_message("assistant").write(answer)


### PR DESCRIPTION
## Summary
- introduce persistence for kernel analogies
- redesign step3 UI to show kernels one-by-one and generate/select analogies

## Testing
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68961c91f464832caf0bfcceafffe2a4