### PR TITLE
feat: allow specifying analogy setting in step3

### DIFF
--- a/src/ui/ai.py
+++ b/src/ui/ai.py
@@ -443,8 +443,13 @@ Our Kernels with Benefits: {kernels_with_benefits}
         return remove_think_block(response.content)
 
 
-def step3a(kernel: dict) -> str:
-        """Find an analogy for a kernel while preserving its benefits."""
+def step3a(kernel: dict, setting: str | None = None) -> str:
+        """Find an analogy for a kernel while preserving its benefits.
+
+        Args:
+                kernel: The kernel data containing the text and benefits.
+                setting: Optional setting to influence the generated analogies.
+        """
         system_prompt = """
 STEP 3A – ANALOGY FOR EACH KERNEL
 Given a kernel and its benefits, produce a concise analogy that explains the kernel and demonstrates why each of its benefits is important.
@@ -525,6 +530,8 @@ wizard spots the anomaly at once, mirroring how quick detection of financial dis
         lc_messages.append(HumanMessage(content=f"Kernel: {kernel_text}"))
         if benefits:
                 lc_messages.append(HumanMessage(content=f"Benefits: {benefits}"))
+        if setting:
+                lc_messages.append(HumanMessage(content=f"Setting: {setting}"))
 
         response = model.invoke(lc_messages)
         return remove_think_block(response.content)

--- a/src/ui/pages/step3.py
+++ b/src/ui/pages/step3.py
@@ -63,10 +63,14 @@ if st.session_state.kernel_index < total:
     st.subheader(f"Kernel {st.session_state.kernel_index + 1} of {total}")
     st.markdown(f"**{k.get('kernel', '')}**")
     manual = st.text_area("Write your own analogies (one per line)", key="manual_analogy")
+    setting = st.text_input(
+        "Optional setting for generated analogies (e.g., fantasy, sci-fi)",
+        key="analogy_setting",
+    )
 
     if st.button("Generate analogies"):
         with st.spinner("Generating analogies..."):
-            raw = ai.step3a(k)
+            raw = ai.step3a(k, setting=setting)
         st.session_state.generated_analogies = parse_analogies(raw)
 
     for idx, ana in enumerate(st.session_state.generated_analogies):
@@ -94,6 +98,7 @@ if st.session_state.kernel_index < total:
         st.session_state.kernel_index += 1
         st.session_state.generated_analogies = []
         st.session_state.manual_analogy = ""
+        st.session_state.analogy_setting = ""
         st.experimental_rerun()
 else:
     st.success("All kernels processed.")


### PR DESCRIPTION
## Summary
- allow user to provide an optional setting for generated analogies in step3
- send the setting through to the analogy prompt

## Testing
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_6897323cd55c832c89bd8fd8cad73c4b