### PR TITLE
feat: support modern streamlit rerun

### DIFF
--- a/src/ui/pages/step3.py
+++ b/src/ui/pages/step3.py
@@ -3,6 +3,14 @@ import streamlit as st
 import app_utils
 import ai
 
+
+def _rerun() -> None:
+    """Trigger a Streamlit rerun compatible across versions."""
+    if hasattr(st, "rerun"):
+        st.rerun()
+    else:
+        st.experimental_rerun()
+
 st.header("Step 3A - Kernel Analogies")
 
 skill_kernels = app_utils.load_skill_kernels()
@@ -105,7 +113,7 @@ if st.session_state.kernel_index < total:
         st.session_state.kernel_index += 1
         st.session_state.generated_analogies = []
         st.session_state.reset_inputs = True
-        st.experimental_rerun()
+        _rerun()
 else:
     st.success("All kernels processed.")
     st.subheader("Selected Analogies")


### PR DESCRIPTION
## Summary
- add compatibility helper to call `st.rerun` when available
- use helper instead of deprecated `st.experimental_rerun`

## Testing
- `pytest`
- `npm test` *(fails: Error: no test specified)*

------
https://chatgpt.com/codex/tasks/task_e_68973ad48354832cb6a22f725866c8e1