### PR TITLE
Handle multiline values in GDSF parser

### DIFF
--- a/src/gdsf/main.py
+++ b/src/gdsf/main.py
@@ -11,29 +11,63 @@ class GDSFParser:
         section = None
         current = {}
         line_num = 0
+        pending_key = None
+        pending_lines: list[str] = []
         with open(filepath) as f:
-            for line_num, line in enumerate(f, start=1):
-                line = line.strip()
-                if not line or line.startswith("#"):
+            for line_num, raw_line in enumerate(f, start=1):
+                stripped = raw_line.strip()
+
+                if pending_key is not None:
+                    # We are collecting a multi-line value. Preserve exact
+                    # line contents (without the trailing newline) including
+                    # blank lines.
+                    pending_lines.append(raw_line.rstrip("\n"))
+                    if stripped.endswith('"'):
+                        value = "\n".join(pending_lines).strip()
+                        if value.startswith('"') and value.endswith('"'):
+                            value = value[1:-1]
+                        current[pending_key] = value
+                        pending_key = None
+                        pending_lines = []
                     continue
-                if line.startswith("[") and line.endswith("]"):
+
+                if not stripped or stripped.startswith("#"):
+                    continue
+
+                if stripped.startswith("[") and stripped.endswith("]"):
                     if section == "schema" and current:
-                        self._append_validated_schema(current,line_num)
+                        self._append_validated_schema(current, line_num)
                     elif section == "edge" and current:
                         self.edges.append(current)
                     elif section == "meta" and current:
                         self.meta.update(current)
                     elif section and current:
                         self.sections[section] = current
-                    section = line[1:-1]
+                    section = stripped[1:-1]
                     current = {}
                 else:
-                    key, value = line.split("=", 1)
-                    current[key.strip()] = value.strip().strip('"')
+                    if "=" not in raw_line:
+                        # Ignore malformed lines outside of a multi-line value
+                        continue
+                    key, value = raw_line.split("=", 1)
+                    key = key.strip()
+                    value = value.strip()
+                    if value.startswith('"') and not value.endswith('"'):
+                        # Begin multi-line value and continue collecting in
+                        # subsequent iterations until we hit a closing quote.
+                        pending_key = key
+                        pending_lines = [value]
+                    else:
+                        current[key] = value.strip('"')
 
             # Add last entry
+            if pending_key is not None:
+                value = "\n".join(pending_lines).strip()
+                if value.startswith('"') and value.endswith('"'):
+                    value = value[1:-1]
+                current[pending_key] = value
             if section == "schema":
-                self._append_validated_schema(current,line_num)
+                self._append_validated_schema(current, line_num)
             elif section == "edge":
                 self.edges.append(current)
             elif section == "meta":

--- a/tests/test_gdsf.py
+++ b/tests/test_gdsf.py
@@ -16,3 +16,15 @@ name = \"Foo\"
         parser = GDSFParser(path)
         assert any(s.get("id") == "T1" for s in parser.schemas)
 
+
+def test_multiline_values_with_blank_lines():
+    content = (
+        "[theme]\n"
+        "value = \"Line1\n\nLine3\"\n"
+    )
+    with tempfile.TemporaryDirectory() as tmpdir:
+        path = Path(tmpdir) / "test.gdsf"
+        path.write_text(content)
+        parser = GDSFParser(path)
+        assert parser.get_section("theme") == {"value": "Line1\n\nLine3"}
+


### PR DESCRIPTION
## Summary
- Support multi-line values with blank lines when parsing GDSF files
- Add regression test for multi-line values with blank lines

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_689762cef290832c9a37bcdcc4b53975