### PR TITLE
Run step3b for each kernel and save mapping

### DIFF
--- a/src/ui/ai.py
+++ b/src/ui/ai.py
@@ -480,6 +480,24 @@ Output format:
         return remove_think_block(response.content)
 
 
+def step3b_all(theme: str, kernels_with_benefits: List[Dict]) -> Dict:
+        """Run step3b separately for each kernel and merge the results."""
+
+        combined = {"kernels": []}
+        for kern in kernels_with_benefits:
+                result = step3b(theme, [kern])
+                cleaned = remove_code_fences(result)
+                try:
+                        parsed = json.loads(cleaned)
+                        if isinstance(parsed, dict) and "kernels" in parsed:
+                                combined["kernels"].extend(parsed["kernels"])
+                        else:
+                                combined["kernels"].append(parsed)
+                except Exception:
+                        combined["kernels"].append(cleaned)
+        return combined
+
+
 def step2(atomic_unit, messages: List[Dict[str, str]]) -> str:
         """Return a chat-based response for choosing atomic skills."""
         system_prompt = """

--- a/src/ui/pages/step3.py
+++ b/src/ui/pages/step3.py
@@ -41,3 +41,60 @@ if prompt:
     st.session_state.messages.append({"role": "assistant", "content": answer})
     st.chat_message("user").write(prompt)
     st.chat_message("assistant").write(answer)
+
+# ---------------------------------------------------------------------------
+# Step 3B – Kernel Theme Mapping
+
+st.subheader("Kernel Theme Mapping")
+
+loaded_mapping = app_utils.load_kernel_theme_mapping()
+if "kernel_theme_text" not in st.session_state:
+    if loaded_mapping:
+        st.session_state.kernel_theme_text = json.dumps(loaded_mapping, indent=2)
+    else:
+        st.session_state.kernel_theme_text = ""
+
+st.text_area(
+    "Provide or edit the kernel theme mapping as JSON",
+    key="kernel_theme_text",
+    height=300,
+)
+
+
+def generate_kernel_theme_mapping():
+    theme_val = app_utils.load_theme()
+    skill_kernels = app_utils.load_skill_kernels()
+    benefits = app_utils.load_kernel_benefits() or {}
+    benefit_maps = app_utils.load_kernel_benefit_mappings() or []
+
+    kernels_list = []
+    if isinstance(skill_kernels, dict):
+        for kern_list in skill_kernels.values():
+            if isinstance(kern_list, list):
+                for kern in kern_list:
+                    kern_benefits = [
+                        m.get("copy_override") or benefits.get(m.get("benefit_id"))
+                        for m in benefit_maps
+                        if m.get("kernel_id") == kern.get("id")
+                        and m.get("benefit_id") in benefits
+                    ]
+                    kernels_list.append(
+                        {
+                            "kernel": kern.get("kernel", ""),
+                            "original_input": kern.get("input", ""),
+                            "original_verb": kern.get("verb", ""),
+                            "original_output": kern.get("output", ""),
+                            "learning_type": kern.get("learning_type", ""),
+                            "benefits": kern_benefits,
+                        }
+                    )
+
+    mapping = ai.step3b_all(theme_val, kernels_list)
+    st.session_state.kernel_theme_text = json.dumps(mapping, indent=2)
+    app_utils.save_kernel_theme_mapping(st.session_state.kernel_theme_text)
+
+
+st.button("Generate Kernel Theme Mapping", on_click=generate_kernel_theme_mapping)
+
+if st.button("Save Kernel Theme Mapping"):
+    app_utils.save_kernel_theme_mapping(st.session_state.kernel_theme_text)

--- a/tests/test_step3b_all.py
+++ b/tests/test_step3b_all.py
@@ -1,0 +1,26 @@
+import json
+from pathlib import Path
+import sys
+import types
+
+# Provide dummy modules for optional dependencies
+sys.modules.setdefault("dotenv", types.SimpleNamespace(load_dotenv=lambda **kwargs: None))
+
+sys.path.append(str(Path(__file__).resolve().parents[1] / "src"))
+import ui.ai as ai  # noqa: E402
+
+
+def test_step3b_all(monkeypatch):
+    calls = []
+
+    def fake_step3b(theme, kernels):
+        calls.append(kernels)
+        return json.dumps({"kernels": [{"kernel": kernels[0]["k"]}]})
+
+    monkeypatch.setattr(ai, "step3b", fake_step3b)
+
+    kernels = [{"k": "one"}, {"k": "two"}]
+    result = ai.step3b_all("T", kernels)
+
+    assert calls == [[{"k": "one"}], [{"k": "two"}]]
+    assert result == {"kernels": [{"kernel": "one"}, {"kernel": "two"}]}


### PR DESCRIPTION
## Summary
- add `step3b_all` helper to iterate step3b over kernels and merge outputs
- extend Step3 UI to generate and edit kernel theme mapping JSON, saving results
- test that `step3b_all` invokes step3b per kernel and aggregates responses

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_6897afa2e3f0832cbcb6d5014e0796cf