### PR TITLE
Include atomic context in mechanic idea generation

### DIFF
--- a/src/ui/ai.py
+++ b/src/ui/ai.py
@@ -716,12 +716,21 @@ Back-ups
 
 
 def step6_mechanic_ideas(
-    layered_feelings: str, medium: str, messages: List[Dict[str, str]]
+    layered_feelings: str,
+    medium: str,
+    atomic_unit: str,
+    atomic_skills,
+    theme_blurb: str,
+    messages: List[Dict[str, str]],
 ) -> str:
         """Suggest mechanics for each feeling."""
 
         system_prompt = f"""
 ### STEP 6A – Map Feelings to Mechanics
+
+Atomic unit: {atomic_unit}
+Atomic skills: {atomic_skills}
+Theme: {theme_blurb}
 
 You are brainstorming **{medium} mechanics** that could evoke each emotional
 state listed below. Return concise suggestions using the format

--- a/src/ui/pages/step6.py
+++ b/src/ui/pages/step6.py
@@ -4,6 +4,10 @@ import ai
 
 st.header("Step 6 - Form a Game (FAG)")
 
+atomic_unit = app_utils.load_atomic_unit()
+atomic_skills = app_utils.load_atomic_skills()
+theme_blurb = app_utils.load_theme()
+
 layer = app_utils.load_layered_feelings()
 if isinstance(layer, dict):
     layer_text = app_utils.layered_feelings_to_text(layer)
@@ -63,7 +67,14 @@ prompt = st.chat_input("Generate Ideas")
 if prompt:
     st.session_state.messages.append({"role": "user", "content": prompt})
     with st.spinner("Generating answer..."):
-        answer = ai.step6_mechanic_ideas(layer_text, medium, st.session_state.messages)
+        answer = ai.step6_mechanic_ideas(
+            layer_text,
+            medium,
+            atomic_unit,
+            atomic_skills,
+            theme_blurb,
+            st.session_state.messages,
+        )
     st.session_state.messages.append({"role": "assistant", "content": answer})
     st.chat_message("user").write(prompt)
     st.chat_message("assistant").write(answer)


### PR DESCRIPTION
## Summary
- Extend `step6_mechanic_ideas` to accept atomic unit, atomic skills, and theme blurb, incorporating them into the prompt for richer mechanic brainstorming.
- Load and pass atomic unit, atomic skills, and theme details in Step 6 UI before invoking the mechanic idea generator.

## Testing
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_6897c10eaa2c832c8bd84bc45789111b