### PR TITLE
Pass atomic context to step7 MVP ideas

### DIFF
--- a/src/ui/ai.py
+++ b/src/ui/ai.py
@@ -765,11 +765,22 @@ Constant pressure: Tight margin of success
         return remove_think_block(response.content)
 
 
-def step7_mvp_ideas(mechanic: str, medium: str, messages: List[Dict[str, str]]) -> str:
+def step7_mvp_ideas(
+    mechanic: str,
+    medium: str,
+    atomic_unit: str,
+    atomic_skills,
+    theme_blurb: str,
+    messages: List[Dict[str, str]],
+) -> str:
         """Suggest schema breakdowns for building the MVP."""
 
         system_prompt = f"""
 ### STEP 7 – From Base Mechanics Tree to MVP (Recursive)
+
+Atomic unit: {atomic_unit}
+Atomic skills: {atomic_skills}
+Theme: {theme_blurb}
 
 We are designing for {medium.lower()}. Break down the mechanic "{mechanic}" step by step.
 Encourage the user to identify concrete game elements, then ask how each one

--- a/src/ui/pages/step7.py
+++ b/src/ui/pages/step7.py
@@ -31,6 +31,9 @@ medium = st.session_state.get("medium", "Video games")
 
 # ---------------------------------------------------------------------------
 # Load data
+atomic_unit = app_utils.load_atomic_unit()
+atomic_skills = app_utils.load_atomic_skills()
+theme_blurb = app_utils.load_theme()
 bmt = app_utils.load_base_mechanics_tree()
 if isinstance(bmt, dict):
     bmt_text = app_utils.layered_feelings_to_text(bmt)
@@ -224,7 +227,14 @@ if prompt:
             )
         else:
             mech = st.session_state.get("current", "") or bmt_text
-            answer = ai.step7_mvp_ideas(mech, medium, st.session_state.messages)
+            answer = ai.step7_mvp_ideas(
+                mech,
+                medium,
+                atomic_unit,
+                atomic_skills,
+                theme_blurb,
+                st.session_state.messages,
+            )
     st.session_state.messages.append({"role": "assistant", "content": answer})
     st.chat_message("user").write(prompt)
     st.chat_message("assistant").write(answer)


### PR DESCRIPTION
## Summary
- extend `step7_mvp_ideas` to include atomic unit, atomic skills, and theme context
- load atomic unit, skills, and theme in Step 7 page and forward to MVP idea generator

## Testing
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_6897c69a6f50832cbe1534ed0b579353